### PR TITLE
Rework testing

### DIFF
--- a/cmd/kivik/main.go
+++ b/cmd/kivik/main.go
@@ -49,6 +49,8 @@ func main() {
 	cmdTest.Flags().StringVarP(&run, "run", "", "", "Run only those tests matching the regular expression")
 	var rw bool
 	cmdTest.Flags().BoolVarP(&rw, "write", "w", false, "Allow tests which write to the database")
+	var cleanup bool
+	cmdTest.Flags().BoolVarP(&cleanup, "cleanup", "c", false, "Clean up after previous test run, then exit")
 	cmdTest.Run = func(cmd *cobra.Command, args []string) {
 		if listTests {
 			test.ListTests()
@@ -65,6 +67,7 @@ func main() {
 			RW:      rw,
 			Suites:  tests,
 			Match:   run,
+			Cleanup: cleanup,
 		})
 	}
 

--- a/test/alldbs.go
+++ b/test/alldbs.go
@@ -31,15 +31,16 @@ func AllDBs(clients *Clients, suite string, t *testing.T) {
 			t.Run("NoAuth", func(t *testing.T) {
 				testAllDBsUnauthorized(client, t)
 			})
-		} else {
-			t.Run("NoAuth", func(t *testing.T) {
-				testAllDBs(client, expected, t)
-			})
+			return
 		}
+		t.Run("NoAuth", func(t *testing.T) {
+			testAllDBs(client, expected, t)
+		})
 	}
 }
 
 func testAllDBsUnauthorized(client *kivik.Client, t *testing.T) {
+	t.Parallel()
 	_, err := client.AllDBs()
 	switch errors.StatusCode(err) {
 	case 0:
@@ -52,6 +53,7 @@ func testAllDBsUnauthorized(client *kivik.Client, t *testing.T) {
 }
 
 func testAllDBs(client *kivik.Client, expected []string, t *testing.T) {
+	t.Parallel()
 	allDBs, err := client.AllDBs()
 	if err != nil {
 		t.Errorf("Failed to get all DBs: %s", err)

--- a/test/alldbs.go
+++ b/test/alldbs.go
@@ -1,5 +1,7 @@
 package test
 
+import "testing"
+
 func init() {
 	for _, suite := range []string{SuitePouchLocal, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant, SuiteKivikServer} {
 		RegisterTest(suite, "AllDBs", false, AllDBs)
@@ -8,7 +10,7 @@ func init() {
 }
 
 // AllDBs tests the '/_all_dbs' endpoint.
-func AllDBs(clients *Clients, suite string, fail FailFunc) {
+func AllDBs(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	var expected []string
 
@@ -18,7 +20,7 @@ func AllDBs(clients *Clients, suite string, fail FailFunc) {
 	}
 	allDBs, err := client.AllDBs()
 	if err != nil {
-		fail("Failed to get all DBs: %s", err)
+		t.Errorf("Failed to get all DBs: %s", err)
 		return
 	}
 	if len(expected) == 0 {
@@ -30,23 +32,23 @@ func AllDBs(clients *Clients, suite string, fail FailFunc) {
 	}
 	for _, exp := range expected {
 		if _, ok := dblist[exp]; !ok {
-			fail("Database '%s' missing from allDBs result", exp)
+			t.Errorf("Database '%s' missing from allDBs result", exp)
 		}
 	}
 }
 
 // AllDBsRW tests the '/_all_dbs' endpoint in RW mode.
-func AllDBsRW(clients *Clients, suite string, fail FailFunc) {
+func AllDBsRW(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	if err := client.CreateDB(testDB); err != nil {
-		fail("Failed to create test DB '%s': %s", testDB, err)
+		t.Errorf("Failed to create test DB '%s': %s", testDB, err)
 		return
 	}
 	defer client.DestroyDB(testDB)
 	allDBs, err := client.AllDBs()
 	if err != nil {
-		fail("Failed to get all DBs: %s", err)
+		t.Errorf("Failed to get all DBs: %s", err)
 		return
 	}
 	for _, db := range allDBs {
@@ -54,5 +56,5 @@ func AllDBsRW(clients *Clients, suite string, fail FailFunc) {
 			return
 		}
 	}
-	fail("Test database '%s' missing from allDbs result", testDB)
+	t.Errorf("Test database '%s' missing from allDbs result", testDB)
 }

--- a/test/createdb.go
+++ b/test/createdb.go
@@ -5,19 +5,18 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/errors"
 )
 
 func init() {
-	for _, suite := range []string{SuitePouchLocal, SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant,
-		SuitePouchRemoteNoAuth, SuiteCouch16NoAuth, SuiteCouch20NoAuth, SuiteCloudantNoAuth} { //FIXME: SuiteKivikServer,SuiteKivikServerNoAuth
+	for _, suite := range []string{SuitePouchLocal, SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant} { //FIXME: SuiteKivikServer
 		RegisterTest(suite, "CreateDB", true, CreateDB)
 	}
 }
 
 // CreateDB tests database creation.
-func CreateDB(client *kivik.Client, suite string, fail FailFunc) {
+func CreateDB(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	testDB := testDBName()
 	fmt.Printf("testDB = %s\n", testDB)
 	// defer client.DestroyDB(testDB)

--- a/test/createdb.go
+++ b/test/createdb.go
@@ -17,35 +17,30 @@ func init() {
 // CreateDB tests database creation.
 func CreateDB(clients *Clients, suite string, t *testing.T) {
 	t.Run("Admin", func(t *testing.T) {
-		testCreateDB(clients.Admin, t)
+		t.Parallel()
+		testDB := testDBName()
+		defer clients.Admin.DestroyDB(testDB)
+		testCreateDB(clients.Admin, testDB, 0, t)
 	})
 	if clients.NoAuth == nil {
 		return
 	}
 	t.Run("NoAuth", func(t *testing.T) {
-		testCreateDBUnauthorized(clients.NoAuth, t)
+		t.Parallel()
+		testDB := testDBName()
+		defer clients.NoAuth.DestroyDB(testDB) // Just in case we succeed
+		testCreateDB(clients.NoAuth, testDB, http.StatusUnauthorized, t)
 	})
 }
 
-func testCreateDBUnauthorized(client *kivik.Client, t *testing.T) {
-	testDB := testDBName()
-	defer client.DestroyDB(testDB) // Just in case we succeed
-	err := client.CreateDB(testDB)
+func testCreateDB(client *kivik.Client, dbName string, status int, t *testing.T) {
+	err := client.CreateDB(dbName)
 	switch errors.StatusCode(err) {
-	case 0:
-		t.Errorf("CreateDB: Should fail for unauthenticated session")
-	case http.StatusUnauthorized:
+	case status:
 		// Expected
+	case 0:
+		t.Errorf("Expected failure creating database '%s' %d/%s", dbName, status, http.StatusText(status))
 	default:
-		t.Errorf("CreateDB: Expected 401/Unauthorized, Got: %s", err)
-	}
-}
-
-func testCreateDB(client *kivik.Client, t *testing.T) {
-	testDB := testDBName()
-	defer client.DestroyDB(testDB)
-	err := client.CreateDB(testDB)
-	if err != nil {
-		t.Errorf("Failed to create database '%s': %s", testDB, err)
+		t.Errorf("Failed to create database '%s': %s", dbName, err)
 	}
 }

--- a/test/createdb.go
+++ b/test/createdb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"testing"
 
 	"github.com/flimzy/kivik/errors"
 )
@@ -15,7 +16,7 @@ func init() {
 }
 
 // CreateDB tests database creation.
-func CreateDB(clients *Clients, suite string, fail FailFunc) {
+func CreateDB(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	fmt.Printf("testDB = %s\n", testDB)
@@ -24,15 +25,15 @@ func CreateDB(clients *Clients, suite string, fail FailFunc) {
 	if strings.Contains(suite, "NoAuth") {
 		switch errors.StatusCode(err) {
 		case 0:
-			fail("CreateDB: Should fail for unauthenticated session")
+			t.Errorf("CreateDB: Should fail for unauthenticated session")
 		case http.StatusUnauthorized:
 			// Expected
 		default:
-			fail("CreateDB: Expected 401/Unauthorized, Got: %s", err)
+			t.Errorf("CreateDB: Expected 401/Unauthorized, Got: %s", err)
 		}
 		return
 	}
 	if err != nil {
-		fail("Failed to create database '%s': %s", testDB, err)
+		t.Errorf("Failed to create database '%s': %s", testDB, err)
 	}
 }

--- a/test/createdb.go
+++ b/test/createdb.go
@@ -21,6 +21,7 @@ func CreateDB(clients *Clients, suite string, t *testing.T) {
 		testDB := testDBName()
 		defer clients.Admin.DestroyDB(testDB)
 		testCreateDB(clients.Admin, testDB, 0, t)
+		testCreateDB(clients.Admin, testDB, http.StatusPreconditionFailed, t)
 	})
 	if clients.NoAuth == nil {
 		return

--- a/test/createdb.go
+++ b/test/createdb.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -19,8 +18,7 @@ func init() {
 func CreateDB(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
-	fmt.Printf("testDB = %s\n", testDB)
-	// defer client.DestroyDB(testDB)
+	defer client.DestroyDB(testDB)
 	err := client.CreateDB(testDB)
 	if strings.Contains(suite, "NoAuth") {
 		switch errors.StatusCode(err) {

--- a/test/db_alldocs.go
+++ b/test/db_alldocs.go
@@ -1,6 +1,12 @@
 package test
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+
+	"github.com/flimzy/kivik"
+	"github.com/flimzy/kivik/errors"
+)
 
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
@@ -13,11 +19,27 @@ func init() {
 }
 
 // AllDocsCouch tests the /{db}/_all_docs endpoint for CouchDB-like backends.
-func AllDocsCouch(clients *Clients, _ string, t *testing.T) {
-	client := clients.Admin
+func AllDocsCouch(clients *Clients, suite string, t *testing.T) {
+	t.Run("Admin", func(t *testing.T) {
+		testAllDocsCouch(clients.Admin, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	expectedStatus := http.StatusForbidden
+	if suite == SuiteCloudant {
+		expectedStatus = http.StatusUnauthorized
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		testAllDocsCouchFailure(clients.NoAuth, expectedStatus, t)
+	})
+}
+
+func testAllDocsCouch(client *kivik.Client, t *testing.T) {
 	db, err := client.DB("_replicator")
 	if err != nil {
 		t.Errorf("Failed to connect to database: %s", err)
+		return
 	}
 	docs := []interface{}{}
 	offset, total, _, err := db.AllDocs(&docs, nil)
@@ -30,5 +52,22 @@ func AllDocsCouch(clients *Clients, _ string, t *testing.T) {
 	}
 	if total < 1 {
 		t.Errorf("Expected total >= 1, got %d", total)
+	}
+}
+
+func testAllDocsCouchFailure(client *kivik.Client, expectedStatus int, t *testing.T) {
+	db, err := client.DB("_replicator")
+	if err != nil {
+		t.Errorf("Failed to connect to database: %s", err)
+		return
+	}
+	_, _, _, err = db.AllDocs(&struct{}{}, nil)
+	switch errors.StatusCode(err) {
+	case 0:
+		t.Errorf("Expected an error")
+	case expectedStatus:
+		// expected
+	default:
+		t.Errorf("Expected %s, got %s", http.StatusText(expectedStatus), err)
 	}
 }

--- a/test/db_alldocs.go
+++ b/test/db_alldocs.go
@@ -1,7 +1,5 @@
 package test
 
-import "github.com/flimzy/kivik"
-
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "AllDocsCouch", false, AllDocsCouch)
@@ -13,7 +11,8 @@ func init() {
 }
 
 // AllDocsCouch tests the /{db}/_all_docs endpoint for CouchDB-like backends.
-func AllDocsCouch(client *kivik.Client, _ string, fail FailFunc) {
+func AllDocsCouch(clients *Clients, _ string, fail FailFunc) {
+	client := clients.Admin
 	db, err := client.DB("_replicator")
 	if err != nil {
 		fail("Failed to connect to database: %s", err)

--- a/test/db_alldocs.go
+++ b/test/db_alldocs.go
@@ -1,5 +1,7 @@
 package test
 
+import "testing"
+
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "AllDocsCouch", false, AllDocsCouch)
@@ -11,22 +13,22 @@ func init() {
 }
 
 // AllDocsCouch tests the /{db}/_all_docs endpoint for CouchDB-like backends.
-func AllDocsCouch(clients *Clients, _ string, fail FailFunc) {
+func AllDocsCouch(clients *Clients, _ string, t *testing.T) {
 	client := clients.Admin
 	db, err := client.DB("_replicator")
 	if err != nil {
-		fail("Failed to connect to database: %s", err)
+		t.Errorf("Failed to connect to database: %s", err)
 	}
 	docs := []interface{}{}
 	offset, total, _, err := db.AllDocs(&docs, nil)
 	if err != nil {
-		fail("Failed to fetch AllDocs: %s", err)
+		t.Errorf("Failed to fetch AllDocs: %s", err)
 		return
 	}
 	if offset != 0 {
-		fail("Expected offset of 0, got %d", offset)
+		t.Errorf("Expected offset of 0, got %d", offset)
 	}
 	if total < 1 {
-		fail("Expected total >= 1, got %d", total)
+		t.Errorf("Expected total >= 1, got %d", total)
 	}
 }

--- a/test/db_put.go
+++ b/test/db_put.go
@@ -1,5 +1,7 @@
 package test
 
+import "testing"
+
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "Put", true, Put)
@@ -14,16 +16,16 @@ type testDoc struct {
 }
 
 // Put tests creating and updating documents.
-func Put(clients *Clients, _ string, fail FailFunc) {
+func Put(clients *Clients, _ string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	defer client.DestroyDB(testDB)
 	if err := client.CreateDB(testDB); err != nil {
-		fail("Failed to create database %s: %s", testDB, err)
+		t.Errorf("Failed to create database %s: %s", testDB, err)
 	}
 	db, err := client.DB(testDB)
 	if err != nil {
-		fail("Failed to connect to test database %s: %s", testDB, err)
+		t.Errorf("Failed to connect to test database %s: %s", testDB, err)
 		return
 	}
 	doc := testDoc{
@@ -33,13 +35,13 @@ func Put(clients *Clients, _ string, fail FailFunc) {
 	}
 	rev, err := db.Put(doc.ID, doc)
 	if err != nil {
-		fail("Failed to create new doc '%s': %s", doc.ID, err)
+		t.Errorf("Failed to create new doc '%s': %s", doc.ID, err)
 		return
 	}
 	doc.Rev = rev
 	doc.Age = 33
 	_, err = db.Put(doc.ID, doc)
 	if err != nil {
-		fail("Failed to update doc '%s'/'%s': %s", doc.ID, rev, err)
+		t.Errorf("Failed to update doc '%s'/'%s': %s", doc.ID, rev, err)
 	}
 }

--- a/test/db_put.go
+++ b/test/db_put.go
@@ -1,7 +1,5 @@
 package test
 
-import "github.com/flimzy/kivik"
-
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "Put", true, Put)
@@ -16,7 +14,8 @@ type testDoc struct {
 }
 
 // Put tests creating and updating documents.
-func Put(client *kivik.Client, _ string, fail FailFunc) {
+func Put(clients *Clients, _ string, fail FailFunc) {
+	client := clients.Admin
 	testDB := testDBName()
 	defer client.DestroyDB(testDB)
 	if err := client.CreateDB(testDB); err != nil {

--- a/test/dbexists.go
+++ b/test/dbexists.go
@@ -9,24 +9,22 @@ import (
 
 func init() {
 	// For these variants, we can do a read-only test, checking for '_users'.
-	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant, SuiteCouch16NoAuth, SuiteCouch20NoAuth} {
+	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "DBExists", false, DBExists)
 	}
-	// For unauthorized Cloudant, we expect an Unauthorized status for this check
-	RegisterTest(SuiteCloudantNoAuth, "DBExistsUnauthorized", false, DBExistsUnauthorized)
 	// For the rest, the only way to be sure a db exists is to create it first
 	for _, suite := range []string{SuitePouchLocal, SuitePouchRemote, SuiteKivikMemory, SuiteKivikServer} {
 		RegisterTest(suite, "DBExistsRW", true, DBExistsRW)
 	}
 	// For all of them, except local PouchDB, we can check for non-existence without writing
-	for _, suite := range []string{SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant, SuiteKivikServer,
-		SuitePouchRemoteNoAuth, SuiteCouch16NoAuth, SuiteCouch20NoAuth, SuiteCloudantNoAuth} {
+	for _, suite := range []string{SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant, SuiteKivikServer} {
 		RegisterTest(suite, "DBNotExists", false, DBNotExists)
 	}
 }
 
 // DBExistsRW creates a test database to check for its existence
-func DBExistsRW(client *kivik.Client, suite string, fail FailFunc) {
+func DBExistsRW(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	testDB := testDBName()
 	defer client.DestroyDB(testDB)
 	if err := client.CreateDB(testDB); err != nil {
@@ -37,19 +35,19 @@ func DBExistsRW(client *kivik.Client, suite string, fail FailFunc) {
 }
 
 // DBExists checks for the existence of the '_users' system database
-func DBExists(client *kivik.Client, suite string, fail FailFunc) {
-	checkDBExists(client, "_users", true, 0, fail)
+func DBExists(clients *Clients, suite string, fail FailFunc) {
+	checkDBExists(clients.Admin, "_users", true, 0, fail)
 }
 
 // DBExistsUnauthorized checks for the existence of the '_users' system database,
 // but expects an unauthorized response
-func DBExistsUnauthorized(client *kivik.Client, suite string, fail FailFunc) {
-	checkDBExists(client, "_users", false, 401, fail)
+func DBExistsUnauthorized(clients *Clients, suite string, fail FailFunc) {
+	checkDBExists(clients.Admin, "_users", false, 401, fail)
 }
 
 // DBNotExists checks that a database does not exist
-func DBNotExists(client *kivik.Client, suite string, fail FailFunc) {
-	checkDBExists(client, testDBName(), false, 0, fail)
+func DBNotExists(clients *Clients, suite string, fail FailFunc) {
+	checkDBExists(clients.Admin, testDBName(), false, 0, fail)
 }
 
 func checkDBExists(client *kivik.Client, dbName string, expected bool, expectedStatus int, fail FailFunc) {

--- a/test/dbexists.go
+++ b/test/dbexists.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"net/http"
+	"testing"
 
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/errors"
@@ -23,43 +24,43 @@ func init() {
 }
 
 // DBExistsRW creates a test database to check for its existence
-func DBExistsRW(clients *Clients, suite string, fail FailFunc) {
+func DBExistsRW(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	defer client.DestroyDB(testDB)
 	if err := client.CreateDB(testDB); err != nil {
-		fail("Failed to create testDB '%s': %s", testDB, err)
+		t.Errorf("Failed to create testDB '%s': %s", testDB, err)
 		return
 	}
-	checkDBExists(client, testDB, true, 0, fail)
+	checkDBExists(client, testDB, true, 0, t)
 }
 
 // DBExists checks for the existence of the '_users' system database
-func DBExists(clients *Clients, suite string, fail FailFunc) {
-	checkDBExists(clients.Admin, "_users", true, 0, fail)
+func DBExists(clients *Clients, suite string, t *testing.T) {
+	checkDBExists(clients.Admin, "_users", true, 0, t)
 }
 
 // DBExistsUnauthorized checks for the existence of the '_users' system database,
 // but expects an unauthorized response
-func DBExistsUnauthorized(clients *Clients, suite string, fail FailFunc) {
-	checkDBExists(clients.Admin, "_users", false, 401, fail)
+func DBExistsUnauthorized(clients *Clients, suite string, t *testing.T) {
+	checkDBExists(clients.Admin, "_users", false, 401, t)
 }
 
 // DBNotExists checks that a database does not exist
-func DBNotExists(clients *Clients, suite string, fail FailFunc) {
-	checkDBExists(clients.Admin, testDBName(), false, 0, fail)
+func DBNotExists(clients *Clients, suite string, t *testing.T) {
+	checkDBExists(clients.Admin, testDBName(), false, 0, t)
 }
 
-func checkDBExists(client *kivik.Client, dbName string, expected bool, expectedStatus int, fail FailFunc) {
+func checkDBExists(client *kivik.Client, dbName string, expected bool, expectedStatus int, t *testing.T) {
 	exists, err := client.DBExists(dbName)
 	status := errors.StatusCode(err)
 	if status == expectedStatus && exists == expected {
 		return
 	}
 	if exists != expected {
-		fail("Returned %t for '%s', expected %t", exists, dbName, expected)
+		t.Errorf("Returned %t for '%s', expected %t", exists, dbName, expected)
 	}
 	if status != expectedStatus {
-		fail("Failed to check existence of '%s'.\n\tExpected: %d/%s\n\t  Actual: %d/%s", dbName, expectedStatus, http.StatusText(expectedStatus), status, err)
+		t.Errorf("Failed to check existence of '%s'.\n\tExpected: %d/%s\n\t  Actual: %d/%s", dbName, expectedStatus, http.StatusText(expectedStatus), status, err)
 	}
 }

--- a/test/dbexists.go
+++ b/test/dbexists.go
@@ -32,23 +32,45 @@ func DBExistsRW(clients *Clients, suite string, t *testing.T) {
 		t.Errorf("Failed to create testDB '%s': %s", testDB, err)
 		return
 	}
-	checkDBExists(client, testDB, true, 0, t)
+	t.Run("Admin", func(t *testing.T) {
+		checkDBExists(clients.Admin, testDB, true, 0, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		checkDBExists(clients.NoAuth, testDB, true, 0, t)
+	})
 }
 
 // DBExists checks for the existence of the '_users' system database
 func DBExists(clients *Clients, suite string, t *testing.T) {
-	checkDBExists(clients.Admin, "_users", true, 0, t)
-}
-
-// DBExistsUnauthorized checks for the existence of the '_users' system database,
-// but expects an unauthorized response
-func DBExistsUnauthorized(clients *Clients, suite string, t *testing.T) {
-	checkDBExists(clients.Admin, "_users", false, 401, t)
+	t.Run("Admin", func(t *testing.T) {
+		checkDBExists(clients.Admin, "_users", true, 0, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		if suite == SuiteCloudant {
+			checkDBExists(clients.NoAuth, "_users", false, http.StatusUnauthorized, t)
+		} else {
+			checkDBExists(clients.NoAuth, "_users", true, 0, t)
+		}
+	})
 }
 
 // DBNotExists checks that a database does not exist
 func DBNotExists(clients *Clients, suite string, t *testing.T) {
-	checkDBExists(clients.Admin, testDBName(), false, 0, t)
+	t.Run("Admin", func(t *testing.T) {
+		checkDBExists(clients.Admin, testDBName(), false, 0, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		checkDBExists(clients.NoAuth, testDBName(), false, 0, t)
+	})
 }
 
 func checkDBExists(client *kivik.Client, dbName string, expected bool, expectedStatus int, t *testing.T) {

--- a/test/destroydb.go
+++ b/test/destroydb.go
@@ -1,6 +1,10 @@
 package test
 
-import "github.com/flimzy/kivik"
+import (
+	"testing"
+
+	"github.com/flimzy/kivik"
+)
 
 func init() {
 	for _, suite := range []string{SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteCloudant} { //FIXME: SuiteKivikServer
@@ -12,27 +16,27 @@ func init() {
 }
 
 // DestroyDB tests database destruction
-func DestroyDB(clients *Clients, suite string, fail FailFunc) {
+func DestroyDB(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	if err := client.CreateDB(testDB); err != nil {
-		fail("Failed to create database '%s': %s", testDB, err)
+		t.Errorf("Failed to create database '%s': %s", testDB, err)
 	}
 	if err := client.DestroyDB(testDB); err != nil {
-		fail("Failed to destroy database '%s': %s", testDB, err)
+		t.Errorf("Failed to destroy database '%s': %s", testDB, err)
 	}
 }
 
 // NotDestroyDB tests that database destruction fails if the db doesn't exist
-func NotDestroyDB(clients *Clients, suite string, fail FailFunc) {
+func NotDestroyDB(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	testDB := testDBName()
 	err := client.DestroyDB(testDB)
 	if err == nil {
-		fail("Database destruction should have failed for non-existent database")
+		t.Errorf("Database destruction should have failed for non-existent database")
 		return
 	}
 	if !kivik.ErrNotFound(err) {
-		fail("Database destruction should have indicated NotFound, but instead: %s", err)
+		t.Errorf("Database destruction should have indicated NotFound, but instead: %s", err)
 	}
 }

--- a/test/destroydb.go
+++ b/test/destroydb.go
@@ -20,22 +20,25 @@ func init() {
 // DestroyDB tests database destruction
 func DestroyDB(clients *Clients, suite string, t *testing.T) {
 	admin := clients.Admin
-	testDB := testDBName()
-	if err := admin.CreateDB(testDB); err != nil {
-		t.Errorf("Failed to create database '%s': %s", testDB, err)
-		return
-	}
 	t.Run("Admin", func(t *testing.T) {
+		t.Parallel()
+		testDB := testDBName()
+		if err := admin.CreateDB(testDB); err != nil {
+			t.Errorf("Failed to create database '%s': %s", testDB, err)
+			return
+		}
 		testDestroyDB(clients.Admin, testDB, 0, t)
 	})
 	if clients.NoAuth == nil {
 		return
 	}
-	if err := admin.CreateDB(testDB); err != nil {
-		t.Errorf("Failed to create database '%s': %s", testDB, err)
-		return
-	}
 	t.Run("NoAuth", func(t *testing.T) {
+		t.Parallel()
+		testDB := testDBName()
+		if err := admin.CreateDB(testDB); err != nil {
+			t.Errorf("Failed to create database '%s': %s", testDB, err)
+			return
+		}
 		testDestroyDB(clients.NoAuth, testDB, http.StatusUnauthorized, t)
 	})
 }

--- a/test/destroydb.go
+++ b/test/destroydb.go
@@ -12,7 +12,8 @@ func init() {
 }
 
 // DestroyDB tests database destruction
-func DestroyDB(client *kivik.Client, suite string, fail FailFunc) {
+func DestroyDB(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	testDB := testDBName()
 	if err := client.CreateDB(testDB); err != nil {
 		fail("Failed to create database '%s': %s", testDB, err)
@@ -23,7 +24,8 @@ func DestroyDB(client *kivik.Client, suite string, fail FailFunc) {
 }
 
 // NotDestroyDB tests that database destruction fails if the db doesn't exist
-func NotDestroyDB(client *kivik.Client, suite string, fail FailFunc) {
+func NotDestroyDB(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	testDB := testDBName()
 	err := client.DestroyDB(testDB)
 	if err == nil {

--- a/test/go17testing.go
+++ b/test/go17testing.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func mainStart(clients *Clients, suites []string, rw bool) {
-	m := testing.MainStart(regexp.MatchString, gatherTests(clients, suites, rw), nil, nil)
+func mainStart(tests []testing.InternalTest) {
+	m := testing.MainStart(regexp.MatchString, tests, nil, nil)
 	os.Exit(m.Run())
 }

--- a/test/go17testing.go
+++ b/test/go17testing.go
@@ -1,0 +1,14 @@
+// +build go1.7,!go1.8
+
+package test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func mainStart(clients *Clients, suites []string, rw bool) {
+	m := testing.MainStart(regexp.MatchString, gatherTests(clients, suites, rw), nil, nil)
+	os.Exit(m.Run())
+}

--- a/test/go18testing.go
+++ b/test/go18testing.go
@@ -30,7 +30,7 @@ func (d *deps) StopCPUProfile()                                   {}
 func (d *deps) WriteHeapProfile(_ io.Writer) error                { return nil }
 func (d *deps) WriteProfileTo(_ string, _ io.Writer, _ int) error { return nil }
 
-func mainStart(clients *Clients, suites []string, rw bool) {
-	m := testing.MainStart(&deps{}, gatherTests(clients, suites, rw), nil, nil)
+func mainStart(tests []testing.InternalTest) {
+	m := testing.MainStart(&deps{}, tests, nil, nil)
 	os.Exit(m.Run())
 }

--- a/test/go18testing.go
+++ b/test/go18testing.go
@@ -1,8 +1,12 @@
+// +build go1.8
+
 package test
 
 import (
 	"io"
+	"os"
 	"regexp"
+	"testing"
 )
 
 /* This file contains copies of basic functionality from the testing package */
@@ -25,3 +29,8 @@ func (d *deps) StartCPUProfile(_ io.Writer) error                 { return nil }
 func (d *deps) StopCPUProfile()                                   {}
 func (d *deps) WriteHeapProfile(_ io.Writer) error                { return nil }
 func (d *deps) WriteProfileTo(_ string, _ io.Writer, _ int) error { return nil }
+
+func mainStart(clients *Clients, suites []string, rw bool) {
+	m := testing.MainStart(&deps{}, gatherTests(clients, suites, rw), nil, nil)
+	os.Exit(m.Run())
+}

--- a/test/go19testing.go
+++ b/test/go19testing.go
@@ -1,4 +1,4 @@
-// +build go1.8,!go1.9
+// +build go1.9
 
 package test
 
@@ -9,8 +9,6 @@ import (
 	"testing"
 )
 
-/* This file contains copies of basic functionality from the testing package */
-
 // testDeps is a copy of testing.testDeps
 type testDeps interface {
 	MatchString(pat, str string) (bool, error)
@@ -18,6 +16,7 @@ type testDeps interface {
 	StopCPUProfile()
 	WriteHeapProfile(io.Writer) error
 	WriteProfileTo(string, io.Writer, int) error
+	ImportPath() string
 }
 
 type deps struct{}
@@ -29,6 +28,7 @@ func (d *deps) StartCPUProfile(_ io.Writer) error                 { return nil }
 func (d *deps) StopCPUProfile()                                   {}
 func (d *deps) WriteHeapProfile(_ io.Writer) error                { return nil }
 func (d *deps) WriteProfileTo(_ string, _ io.Writer, _ int) error { return nil }
+func (d *deps) ImportPath() string                                { return "" }
 
 func mainStart(clients *Clients, suites []string, rw bool) {
 	m := testing.MainStart(&deps{}, gatherTests(clients, suites, rw), nil, nil)

--- a/test/go19testing.go
+++ b/test/go19testing.go
@@ -30,7 +30,7 @@ func (d *deps) WriteHeapProfile(_ io.Writer) error                { return nil }
 func (d *deps) WriteProfileTo(_ string, _ io.Writer, _ int) error { return nil }
 func (d *deps) ImportPath() string                                { return "" }
 
-func mainStart(clients *Clients, suites []string, rw bool) {
-	m := testing.MainStart(&deps{}, gatherTests(clients, suites, rw), nil, nil)
+func mainStart(tests []testing.InternalTest) {
+	m := testing.MainStart(&deps{}, tests, nil, nil)
 	os.Exit(m.Run())
 }

--- a/test/gopherjs_test.go
+++ b/test/gopherjs_test.go
@@ -25,7 +25,7 @@ func TestPouchLocal(t *testing.T) {
 		t.Errorf("Failed to connect to PouchDB/memdown driver: %s", err)
 		return
 	}
-	RunSubtests(client, true, []string{SuitePouchLocal}, t)
+	RunSubtests(client, true, SuitePouchLocal, t)
 }
 
 func TestPouchRemote(t *testing.T) {

--- a/test/gopherjs_test.go
+++ b/test/gopherjs_test.go
@@ -32,9 +32,5 @@ func TestPouchLocal(t *testing.T) {
 }
 
 func TestPouchRemote(t *testing.T) {
-	doTest(SuitePouchRemote, "KIVIK_COUCH16_DSN", true, t)
-}
-
-func TestPouchRemoteNoAuth(t *testing.T) {
-	doTest(SuitePouchRemoteNoAuth, "KIVIK_COUCH16_DSN", false, t)
+	doTest(SuitePouchRemote, "KIVIK_TEST_DSN_COUCH16", true, t)
 }

--- a/test/gopherjs_test.go
+++ b/test/gopherjs_test.go
@@ -25,7 +25,10 @@ func TestPouchLocal(t *testing.T) {
 		t.Errorf("Failed to connect to PouchDB/memdown driver: %s", err)
 		return
 	}
-	RunSubtests(client, true, SuitePouchLocal, t)
+	clients := &Clients{
+		Admin: client,
+	}
+	RunSubtests(clients, true, SuitePouchLocal, t)
 }
 
 func TestPouchRemote(t *testing.T) {

--- a/test/info.go
+++ b/test/info.go
@@ -1,10 +1,6 @@
 package test
 
-import (
-	"regexp"
-
-	"github.com/flimzy/kivik"
-)
+import "regexp"
 
 func init() {
 	for _, suite := range AllSuites {
@@ -37,7 +33,8 @@ var vendorVersionREs = map[string]*regexp.Regexp{
 }
 
 // ServerInfo tests the '/' endpoint
-func ServerInfo(client *kivik.Client, suite string, fail FailFunc) {
+func ServerInfo(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	info, err := client.ServerInfo()
 	if err != nil {
 		fail("%s", err)

--- a/test/info.go
+++ b/test/info.go
@@ -3,6 +3,8 @@ package test
 import (
 	"regexp"
 	"testing"
+
+	"github.com/flimzy/kivik"
 )
 
 func init() {
@@ -37,7 +39,19 @@ var vendorVersionREs = map[string]*regexp.Regexp{
 
 // ServerInfo tests the '/' endpoint
 func ServerInfo(clients *Clients, suite string, t *testing.T) {
-	client := clients.Admin
+	t.Run("Admin", func(t *testing.T) {
+		testServerInfo(clients.Admin, suite, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		testServerInfo(clients.NoAuth, suite, t)
+	})
+}
+
+func testServerInfo(client *kivik.Client, suite string, t *testing.T) {
+	t.Parallel()
 	info, err := client.ServerInfo()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/test/info.go
+++ b/test/info.go
@@ -1,6 +1,9 @@
 package test
 
-import "regexp"
+import (
+	"regexp"
+	"testing"
+)
 
 func init() {
 	for _, suite := range AllSuites {
@@ -33,26 +36,26 @@ var vendorVersionREs = map[string]*regexp.Regexp{
 }
 
 // ServerInfo tests the '/' endpoint
-func ServerInfo(clients *Clients, suite string, fail FailFunc) {
+func ServerInfo(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	info, err := client.ServerInfo()
 	if err != nil {
-		fail("%s", err)
+		t.Errorf("%s", err)
 		return
 	}
 	if re, ok := versionREs[suite]; ok {
 		if !re.MatchString(info.Version()) {
-			fail("Version %s does not match %s\n", info.Version(), re)
+			t.Errorf("Version %s does not match %s\n", info.Version(), re)
 		}
 	}
 	if name, ok := vendorNames[suite]; ok {
 		if name != info.Vendor() {
-			fail("ServerInfo: Vendor Name %s does not match %s\n", info.Vendor(), name)
+			t.Errorf("ServerInfo: Vendor Name %s does not match %s\n", info.Vendor(), name)
 		}
 	}
 	if re, ok := vendorVersionREs[suite]; ok {
 		if !re.MatchString(info.VendorVersion()) {
-			fail("Vendor Version %s does not match %s\n", info.VendorVersion(), re)
+			t.Errorf("Vendor Version %s does not match %s\n", info.VendorVersion(), re)
 		}
 	}
 }

--- a/test/log.go
+++ b/test/log.go
@@ -5,7 +5,11 @@
 
 package test
 
-import "github.com/flimzy/kivik"
+import (
+	"testing"
+
+	"github.com/flimzy/kivik"
+)
 
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20} { //FIXME: SuiteKivikServer
@@ -15,27 +19,27 @@ func init() {
 }
 
 // Log tests the /_log endpoint
-func Log(clients *Clients, suite string, fail FailFunc) {
+func Log(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	logBuf := make([]byte, 1000)
 	if _, err := client.Log(logBuf, 0); err != nil {
-		fail("Error reading 1000 log bytes: %s", err)
+		t.Errorf("Error reading 1000 log bytes: %s", err)
 	}
 	logBuf = make([]byte, 0, 1000)
 	if _, err := client.Log(logBuf, 0); err != nil {
-		fail("Error reading 0 log bytes: %s", err)
+		t.Errorf("Error reading 0 log bytes: %s", err)
 	}
 }
 
 // CloudantLog tests the /_log endpoint for Cloudant, which returns an error
-func CloudantLog(clients *Clients, suite string, fail FailFunc) {
+func CloudantLog(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	logBuf := make([]byte, 1000)
 	_, err := client.Log(logBuf, 0)
 	if err == nil {
-		fail("Expected an error")
+		t.Errorf("Expected an error")
 	}
 	if !kivik.ErrForbidden(err) {
-		fail("Expected 403/Forbidden, got %s", err)
+		t.Errorf("Expected 403/Forbidden, got %s", err)
 	}
 }

--- a/test/log.go
+++ b/test/log.go
@@ -15,7 +15,8 @@ func init() {
 }
 
 // Log tests the /_log endpoint
-func Log(client *kivik.Client, suite string, fail FailFunc) {
+func Log(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	logBuf := make([]byte, 1000)
 	if _, err := client.Log(logBuf, 0); err != nil {
 		fail("Error reading 1000 log bytes: %s", err)
@@ -27,7 +28,8 @@ func Log(client *kivik.Client, suite string, fail FailFunc) {
 }
 
 // CloudantLog tests the /_log endpoint for Cloudant, which returns an error
-func CloudantLog(client *kivik.Client, suite string, fail FailFunc) {
+func CloudantLog(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	logBuf := make([]byte, 1000)
 	_, err := client.Log(logBuf, 0)
 	if err == nil {

--- a/test/membership.go
+++ b/test/membership.go
@@ -1,5 +1,7 @@
 package test
 
+import "testing"
+
 func init() {
 	for _, suite := range []string{SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "Membership", false, Membership)
@@ -7,21 +9,21 @@ func init() {
 }
 
 // Membership tests the /_membership endpoint
-func Membership(clients *Clients, suite string, fail FailFunc) {
+func Membership(clients *Clients, suite string, t *testing.T) {
 	client := clients.Admin
 	all, cluster, err := client.Membership()
 	if err != nil {
-		fail("Failed to read membership: %s", err)
+		t.Errorf("t.Errorfed to read membership: %s", err)
 	}
 	if suite == SuiteCloudant {
 		if len(all) < 2 {
-			fail("Only got %d nodes, expected 2+\n", len(all))
+			t.Errorf("Only got %d nodes, expected 2+\n", len(all))
 		}
 		if len(cluster) < 2 {
-			fail("Only got %d cluster nodes, expected 2+\n", len(cluster))
+			t.Errorf("Only got %d cluster nodes, expected 2+\n", len(cluster))
 		}
 	}
 	if len(all) < len(cluster) {
-		fail("Cluster list (%d) shorter than full list (%d) (!!?!)", len(cluster), len(all))
+		t.Errorf("Cluster list (%d) shorter than full list (%d) (!!?!)", len(cluster), len(all))
 	}
 }

--- a/test/membership.go
+++ b/test/membership.go
@@ -1,6 +1,12 @@
 package test
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+
+	"github.com/flimzy/kivik"
+	"github.com/flimzy/kivik/errors"
+)
 
 func init() {
 	for _, suite := range []string{SuiteCouch20, SuiteCloudant} {
@@ -10,10 +16,27 @@ func init() {
 
 // Membership tests the /_membership endpoint
 func Membership(clients *Clients, suite string, t *testing.T) {
-	client := clients.Admin
-	all, cluster, err := client.Membership()
-	if err != nil {
-		t.Errorf("t.Errorfed to read membership: %s", err)
+	t.Run("Admin", func(t *testing.T) {
+		testMembership(clients.Admin, suite, 0, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		if suite == SuiteCloudant {
+			testMembership(clients.NoAuth, suite, http.StatusUnauthorized, t)
+			return
+		}
+		testMembership(clients.NoAuth, suite, 0, t)
+	})
+}
+
+func testMembership(client *kivik.Client, suite string, status int, t *testing.T) {
+	t.Parallel()
+	all, cluster := readMembership(client, status, t)
+	if status > 0 {
+		// Expected failure, so skip the rest
+		return
 	}
 	if suite == SuiteCloudant {
 		if len(all) < 2 {
@@ -26,4 +49,18 @@ func Membership(clients *Clients, suite string, t *testing.T) {
 	if len(all) < len(cluster) {
 		t.Errorf("Cluster list (%d) shorter than full list (%d) (!!?!)", len(cluster), len(all))
 	}
+}
+
+func readMembership(client *kivik.Client, status int, t *testing.T) (all, cluster []string) {
+	var err error
+	all, cluster, err = client.Membership()
+	switch errors.StatusCode(err) {
+	case status:
+		return
+	case 0:
+		t.Errorf("Expected failure %d/%s", status, http.StatusText(status))
+	default:
+		t.Errorf("Failed to read membership: %s", err)
+	}
+	return
 }

--- a/test/membership.go
+++ b/test/membership.go
@@ -1,7 +1,5 @@
 package test
 
-import "github.com/flimzy/kivik"
-
 func init() {
 	for _, suite := range []string{SuiteCouch20, SuiteCloudant} {
 		RegisterTest(suite, "Membership", false, Membership)
@@ -9,7 +7,8 @@ func init() {
 }
 
 // Membership tests the /_membership endpoint
-func Membership(client *kivik.Client, suite string, fail FailFunc) {
+func Membership(clients *Clients, suite string, fail FailFunc) {
+	client := clients.Admin
 	all, cluster, err := client.Membership()
 	if err != nil {
 		fail("Failed to read membership: %s", err)

--- a/test/nonjs_test.go
+++ b/test/nonjs_test.go
@@ -28,5 +28,5 @@ func TestFS(t *testing.T) {
 		t.Errorf("Failed to connect to FS driver: %s\n", err)
 		return
 	}
-	RunSubtests(client, true, []string{SuiteKivikFS}, t)
+	RunSubtests(client, true, SuiteKivikFS, t)
 }

--- a/test/nonjs_test.go
+++ b/test/nonjs_test.go
@@ -28,5 +28,8 @@ func TestFS(t *testing.T) {
 		t.Errorf("Failed to connect to FS driver: %s\n", err)
 		return
 	}
-	RunSubtests(client, true, SuiteKivikFS, t)
+	clients := &Clients{
+		Admin: client,
+	}
+	RunSubtests(clients, true, SuiteKivikFS, t)
 }

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -24,5 +24,8 @@ func TestServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to initialize client: %s\n", err)
 	}
-	RunSubtests(client, true, SuiteKivikServer, t)
+	clients := &Clients{
+		Admin: client,
+	}
+	RunSubtests(clients, true, SuiteKivikServer, t)
 }

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -24,5 +24,5 @@ func TestServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to initialize client: %s\n", err)
 	}
-	RunSubtests(client, true, []string{SuiteKivikServer}, t)
+	RunSubtests(client, true, SuiteKivikServer, t)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -16,36 +16,38 @@ import (
 
 // The available test suites
 const (
-	SuiteAuto              = "auto"
-	SuitePouchLocal        = "pouch"
-	SuitePouchRemote       = "pouchRemote"
-	SuitePouchRemoteNoAuth = "pouchRemoteNoAuth"
-	SuiteCouch16           = "couch16"
-	SuiteCouch16NoAuth     = "couch16NoAuth"
-	SuiteCouch20           = "couch20"
-	SuiteCouch20NoAuth     = "couch20NoAuth"
-	SuiteCloudant          = "cloudant"
-	SuiteCloudantNoAuth    = "cloudantNoAuth"
-	SuiteKivikServer       = "kivikServer"
-	SuiteKivikServerNoAuth = "kivikServerNoAuth"
-	SuiteKivikMemory       = "kivikMemory"
-	SuiteKivikFS           = "kivikFilesystem"
+	SuiteAuto        = "auto"
+	SuitePouchLocal  = "pouch"
+	SuitePouchRemote = "pouchRemote"
+	SuiteCouch16     = "couch16"
+	SuiteCouch20     = "couch20"
+	SuiteCloudant    = "cloudant"
+	SuiteKivikServer = "kivikServer"
+	SuiteKivikMemory = "kivikMemory"
+	SuiteKivikFS     = "kivikFilesystem"
 )
 
+// AllSuites is a list of all defined suites.
+var AllSuites = []string{
+	SuitePouchLocal,
+	SuitePouchRemote,
+	SuiteCouch16,
+	SuiteCouch20,
+	SuiteKivikMemory,
+	SuiteKivikFS,
+	SuiteCloudant,
+	SuiteKivikServer,
+}
+
 var driverMap = map[string]string{
-	SuitePouchLocal:        "pouch",
-	SuitePouchRemote:       "pouch",
-	SuitePouchRemoteNoAuth: "pouch",
-	SuiteCouch16:           "couch",
-	SuiteCouch16NoAuth:     "couch",
-	SuiteCouch20:           "couch",
-	SuiteCouch20NoAuth:     "couch",
-	SuiteCloudant:          "couch",
-	SuiteCloudantNoAuth:    "couch",
-	SuiteKivikServer:       "couch",
-	SuiteKivikServerNoAuth: "couch",
-	SuiteKivikMemory:       "memory",
-	SuiteKivikFS:           "fs",
+	SuitePouchLocal:  "pouch",
+	SuitePouchRemote: "pouch",
+	SuiteCouch16:     "couch",
+	SuiteCouch20:     "couch",
+	SuiteCloudant:    "couch",
+	SuiteKivikServer: "couch",
+	SuiteKivikMemory: "memory",
+	SuiteKivikFS:     "fs",
 }
 
 var rnd *rand.Rand
@@ -57,9 +59,6 @@ func init() {
 func testDBName() string {
 	return fmt.Sprintf("kivik$%016x", rnd.Int63())
 }
-
-// AllSuites is a list of all defined suites.
-var AllSuites = []string{SuitePouchLocal, SuitePouchRemote, SuiteCouch16, SuiteCouch20, SuiteKivikMemory, SuiteKivikFS, SuiteCloudant, SuiteKivikServer}
 
 // ListTests prints a list of available test suites to stdout.
 func ListTests() {

--- a/test/test.go
+++ b/test/test.go
@@ -138,7 +138,9 @@ func mainTest(driver, dsn string, rw bool, testSuites []string, t Tester) {
 		testSuites = append(testSuites, test)
 	}
 	fmt.Printf("Running the following test suites: %s\n", strings.Join(testSuites, ", "))
-	RunSubtests(client, rw, testSuites, t)
+	for _, suite := range testSuites {
+		RunSubtests(client, rw, suite, t)
+	}
 }
 
 func detectCompatibility(client *kivik.Client) ([]string, error) {
@@ -189,15 +191,13 @@ func RegisterTest(suite, name string, rw bool, fn testFunc) {
 type FailFunc func(format string, args ...interface{})
 
 // RunSubtests executes the requested suites of tests against the client.
-func RunSubtests(client *kivik.Client, rw bool, suites []string, t Tester) {
-	for _, suite := range suites {
-		for name, fn := range tests[suite] {
+func RunSubtests(client *kivik.Client, rw bool, suite string, t Tester) {
+	for name, fn := range tests[suite] {
+		runTest(client, name, suite, fn, t)
+	}
+	if rw {
+		for name, fn := range rwtests[suite] {
 			runTest(client, name, suite, fn, t)
-		}
-		if rw {
-			for name, fn := range rwtests[suite] {
-				runTest(client, name, suite, fn, t)
-			}
 		}
 	}
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -18,7 +18,7 @@ func TestMemory(t *testing.T) {
 		t.Errorf("Failed to connect to memory driver: %s\n", err)
 		return
 	}
-	RunSubtests(client, true, []string{SuiteKivikMemory}, t)
+	RunSubtests(client, true, SuiteKivikMemory, t)
 }
 
 func doTest(suite, envName string, requireAuth bool, t *testing.T) {
@@ -44,7 +44,7 @@ func doTest(suite, envName string, requireAuth bool, t *testing.T) {
 		t.Errorf("Failed to connect to %s: %s\n", suite, err)
 		return
 	}
-	RunSubtests(client, true, []string{suite}, t)
+	RunSubtests(client, true, suite, t)
 
 }
 

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"fmt"
-	"net/url"
 	"os"
 	"testing"
 
@@ -18,7 +16,10 @@ func TestMemory(t *testing.T) {
 		t.Errorf("Failed to connect to memory driver: %s\n", err)
 		return
 	}
-	RunSubtests(client, true, SuiteKivikMemory, t)
+	clients := &Clients{
+		Admin: client,
+	}
+	RunSubtests(clients, true, SuiteKivikMemory, t)
 }
 
 func doTest(suite, envName string, requireAuth bool, t *testing.T) {
@@ -26,25 +27,12 @@ func doTest(suite, envName string, requireAuth bool, t *testing.T) {
 	if dsn == "" {
 		t.Skip("%s: %s DSN not set; skipping tests", envName, suite)
 	}
-	parsed, err := url.Parse(dsn)
-	if err != nil {
-		panic(err)
-	}
-	if requireAuth {
-		if parsed.User == nil {
-			t.Skip("%s: %s DSN does not include auth; skipping tests", envName, suite)
-		}
-	} else {
-		parsed.User = nil
-		dsn = parsed.String()
-	}
-	fmt.Printf("dsn = %s\n", dsn)
-	client, err := kivik.New(driverMap[suite], dsn)
+	clients, err := connectClients(driverMap[suite], dsn)
 	if err != nil {
 		t.Errorf("Failed to connect to %s: %s\n", suite, err)
 		return
 	}
-	RunSubtests(client, true, suite, t)
+	RunSubtests(clients, true, suite, t)
 
 }
 

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -27,13 +27,12 @@ func doTest(suite, envName string, requireAuth bool, t *testing.T) {
 	if dsn == "" {
 		t.Skip("%s: %s DSN not set; skipping tests", envName, suite)
 	}
-	clients, err := connectClients(driverMap[suite], dsn)
+	clients, err := connectClients(driverMap[suite], dsn, t)
 	if err != nil {
 		t.Errorf("Failed to connect to %s: %s\n", suite, err)
 		return
 	}
 	RunSubtests(clients, true, suite, t)
-
 }
 
 func TestCloudant(t *testing.T) {

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -37,25 +37,13 @@ func doTest(suite, envName string, requireAuth bool, t *testing.T) {
 }
 
 func TestCloudant(t *testing.T) {
-	doTest(SuiteCloudant, "KIVIK_CLOUDANT_DSN", true, t)
-}
-
-func TestCloudantNoAuth(t *testing.T) {
-	doTest(SuiteCloudantNoAuth, "KIVIK_CLOUDANT_DSN", false, t)
+	doTest(SuiteCloudant, "KIVIK_TEST_DSN_CLOUDANT", true, t)
 }
 
 func TestCouch16(t *testing.T) {
-	doTest(SuiteCouch16, "KIVIK_COUCH16_DSN", true, t)
-}
-
-func TestCouch16NoAuth(t *testing.T) {
-	doTest(SuiteCouch16NoAuth, "KIVIK_COUCH16_DSN", false, t)
+	doTest(SuiteCouch16, "KIVIK_TEST_DSN_COUCH16", true, t)
 }
 
 func TestCouch20(t *testing.T) {
-	doTest(SuiteCouch20, "KIVIK_COUCH20_DSN", true, t)
-}
-
-func TestCouch20NoAuth(t *testing.T) {
-	doTest(SuiteCouch20NoAuth, "KIVIK_COUCH20_DSN", false, t)
+	doTest(SuiteCouch20, "KIVIK_TEST_DSN_COUCH20", true, t)
 }

--- a/test/testing.go
+++ b/test/testing.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"io"
+	"regexp"
+)
+
+/* This file contains copies of basic functionality from the testing package */
+
+// testDeps is a copy of testing.testDeps
+type testDeps interface {
+	MatchString(pat, str string) (bool, error)
+	StartCPUProfile(io.Writer) error
+	StopCPUProfile()
+	WriteHeapProfile(io.Writer) error
+	WriteProfileTo(string, io.Writer, int) error
+}
+
+type deps struct{}
+
+var _ testDeps = &deps{}
+
+func (d *deps) MatchString(pat, str string) (bool, error)         { return regexp.MatchString(pat, str) }
+func (d *deps) StartCPUProfile(_ io.Writer) error                 { return nil }
+func (d *deps) StopCPUProfile()                                   {}
+func (d *deps) WriteHeapProfile(_ io.Writer) error                { return nil }
+func (d *deps) WriteProfileTo(_ string, _ io.Writer, _ int) error { return nil }

--- a/test/uuids.go
+++ b/test/uuids.go
@@ -1,5 +1,7 @@
 package test
 
+import "testing"
+
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant, SuiteKivikMemory} { // FIXME: SuiteKivikServer,
 		RegisterTest(suite, "UUIDs", false, UUIDs)
@@ -7,14 +9,14 @@ func init() {
 }
 
 // UUIDs tests the '/_uuids' endpoint
-func UUIDs(clients *Clients, _ string, fail FailFunc) {
+func UUIDs(clients *Clients, _ string, t *testing.T) {
 	client := clients.Admin
 	uuidCount := 3
 	uuids, err := client.UUIDs(uuidCount)
 	if err != nil {
-		fail("Failed to get UUIDs: %s", err)
+		t.Errorf("Failed to get UUIDs: %s", err)
 	}
 	if len(uuids) != uuidCount {
-		fail("Expected %d UUIDs, got %d\n", uuidCount, len(uuids))
+		t.Errorf("Expected %d UUIDs, got %d\n", uuidCount, len(uuids))
 	}
 }

--- a/test/uuids.go
+++ b/test/uuids.go
@@ -1,7 +1,5 @@
 package test
 
-import "github.com/flimzy/kivik"
-
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant, SuiteKivikMemory} { // FIXME: SuiteKivikServer,
 		RegisterTest(suite, "UUIDs", false, UUIDs)
@@ -9,7 +7,8 @@ func init() {
 }
 
 // UUIDs tests the '/_uuids' endpoint
-func UUIDs(client *kivik.Client, _ string, fail FailFunc) {
+func UUIDs(clients *Clients, _ string, fail FailFunc) {
+	client := clients.Admin
 	uuidCount := 3
 	uuids, err := client.UUIDs(uuidCount)
 	if err != nil {

--- a/test/uuids.go
+++ b/test/uuids.go
@@ -1,6 +1,10 @@
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/flimzy/kivik"
+)
 
 func init() {
 	for _, suite := range []string{SuiteCouch16, SuiteCouch20, SuiteCloudant, SuiteKivikMemory} { // FIXME: SuiteKivikServer,
@@ -10,7 +14,19 @@ func init() {
 
 // UUIDs tests the '/_uuids' endpoint
 func UUIDs(clients *Clients, _ string, t *testing.T) {
-	client := clients.Admin
+	t.Run("Admin", func(t *testing.T) {
+		testUUIDs(clients.Admin, t)
+	})
+	if clients.NoAuth == nil {
+		return
+	}
+	t.Run("NoAuth", func(t *testing.T) {
+		testUUIDs(clients.NoAuth, t)
+	})
+}
+
+func testUUIDs(client *kivik.Client, t *testing.T) {
+	t.Parallel()
 	uuidCount := 3
 	uuids, err := client.UUIDs(uuidCount)
 	if err != nil {


### PR DESCRIPTION
Several changes related to testing:

- Use the `testing` package again, and make it work with Go 1.7, 1.8, and 1.9
- Use `t.Parallel()` where possible.
- Add a test cleanup mode to the command line tool.
- Run tests for unauthenticated users now, too.
- Test CreateDB() for when the db already exists.

And other misc changes.