### PR TITLE
Enforce escaping of document names

### DIFF
--- a/driver/couchdb/chttp/chttp.go
+++ b/driver/couchdb/chttp/chttp.go
@@ -200,10 +200,6 @@ func (c *Client) DoReq(ctx context.Context, method, path string, opts *Options) 
 // fixPath sets the request's URL.RawPath to work with escaped '/' chars in
 // paths.
 func fixPath(req *http.Request, path string) {
-	if !strings.Contains(path, "%2F") {
-		// No need for special treatment
-		return
-	}
 	// Remove any query parameters
 	parts := strings.Split(path, "?")
 	req.URL.RawPath = "/" + strings.TrimPrefix(parts[0], "/")

--- a/driver/couchdb/db.go
+++ b/driver/couchdb/db.go
@@ -136,6 +136,12 @@ const (
 // encodeDocID ensures that any '/' chars in the docID are escaped, except
 // those found in the strings '_design/' and '_local'
 func encodeDocID(docID string) string {
+	parts := strings.Split(docID, "/")
+	for i, part := range parts {
+		parts[i] = url.QueryEscape(part)
+	}
+	docID = strings.Join(parts, "/")
+
 	for _, prefix := range []string{prefixDesign, prefixLocal} {
 		if strings.HasPrefix(docID, prefix) {
 			return prefix + replaceSlash(strings.TrimPrefix(docID, prefix))


### PR DESCRIPTION
This one I'm not 100% sure about. What happens is that I am using emails as document IDs and one of the emails has a `+` in it, which breaks kivik. I looked at requests coming from Fauxton and apparently when there are any weird characters it starts using URL encoding.

The implementation is quite slow, you might want to write it differently. Additionally I only fixed CouchDB, other drivers might have the same issue.