### PR TITLE
Properly encode a wider range of special characters in Document IDs

### DIFF
--- a/driver/couchdb/attachments.go
+++ b/driver/couchdb/attachments.go
@@ -26,7 +26,7 @@ func (d *db) PutAttachmentContext(ctx context.Context, docID, rev, filename, con
 	var response struct {
 		Rev string `json:"rev"`
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodPut, d.path(encodeDocID(docID)+"/"+filename, query), opts, &response)
+	_, err = d.Client.DoJSON(ctx, kivik.MethodPut, d.path(chttp.EncodeDocID(docID)+"/"+filename, query), opts, &response)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func (d *db) fetchAttachment(ctx context.Context, method, docID, rev, filename s
 	if rev != "" {
 		query.Add("rev", rev)
 	}
-	resp, err := d.Client.DoReq(ctx, method, d.path(encodeDocID(docID)+"/"+filename, query), nil)
+	resp, err := d.Client.DoReq(ctx, method, d.path(chttp.EncodeDocID(docID)+"/"+filename, query), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (d *db) DeleteAttachmentContext(ctx context.Context, docID, rev, filename s
 	var response struct {
 		Rev string `json:"rev"`
 	}
-	_, err = d.Client.DoJSON(ctx, kivik.MethodDelete, d.path(encodeDocID(docID)+"/"+filename, query), nil, &response)
+	_, err = d.Client.DoJSON(ctx, kivik.MethodDelete, d.path(chttp.EncodeDocID(docID)+"/"+filename, query), nil, &response)
 	if err != nil {
 		return "", err
 	}

--- a/driver/couchdb/chttp/chttp.go
+++ b/driver/couchdb/chttp/chttp.go
@@ -200,12 +200,8 @@ func (c *Client) DoReq(ctx context.Context, method, path string, opts *Options) 
 // fixPath sets the request's URL.RawPath to work with escaped '/' chars in
 // paths.
 func fixPath(req *http.Request, path string) {
-	if !strings.Contains(path, "%2F") {
-		// No need for special treatment
-		return
-	}
 	// Remove any query parameters
-	parts := strings.Split(path, "?")
+	parts := strings.SplitN(path, "?", 2)
 	req.URL.RawPath = "/" + strings.TrimPrefix(parts[0], "/")
 }
 

--- a/driver/couchdb/chttp/encode.go
+++ b/driver/couchdb/chttp/encode.go
@@ -1,0 +1,25 @@
+package chttp
+
+import (
+	"net/url"
+	"strings"
+)
+
+const (
+	prefixDesign = "_design/"
+	prefixLocal  = "_local/"
+)
+
+// EncodeDocID encodes a document ID according to CouchDB's path encoding rules.
+//
+// In particular:
+// -  '_design/' and '_local/' prefixes are unaltered.
+// - The rest of the docID is Query-URL encoded (despite being part of the path)
+func EncodeDocID(docID string) string {
+	for _, prefix := range []string{prefixDesign, prefixLocal} {
+		if strings.HasPrefix(docID, prefix) {
+			return prefix + url.QueryEscape(strings.TrimPrefix(docID, prefix))
+		}
+	}
+	return url.QueryEscape(docID)
+}

--- a/driver/couchdb/chttp/encode_test.go
+++ b/driver/couchdb/chttp/encode_test.go
@@ -1,0 +1,26 @@
+package chttp
+
+import "testing"
+
+func TestEncodeDocID(t *testing.T) {
+	tests := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "foo", Expected: "foo"},
+		{Input: "foo/bar", Expected: "foo%2Fbar"},
+		{Input: "_design/foo", Expected: "_design/foo"},
+		{Input: "_design/foo/bar", Expected: "_design/foo%2Fbar"},
+		{Input: "foo@bar.com", Expected: "foo%40bar.com"},
+		{Input: "foo+bar@baz.com", Expected: "foo%2Bbar%40baz.com"},
+		{Input: "Is this a valid ID?", Expected: "Is+this+a+valid+ID%3F"},
+		{Input: "nón-English-çharacters", Expected: "n%C3%B3n-English-%C3%A7haracters"},
+		{Input: "foo+bar & páces?!*,", Expected: "foo%2Bbar+%26+p%C3%A1ces%3F%21%2A%2C"},
+	}
+	for _, test := range tests {
+		result := EncodeDocID(test.Input)
+		if result != test.Expected {
+			t.Errorf("Unexpected encoded DocID from %s\n\tExpected: %s\n\t  Actual: %s\n", test.Input, test.Expected, result)
+		}
+	}
+}

--- a/driver/couchdb/db_test.go
+++ b/driver/couchdb/db_test.go
@@ -47,21 +47,3 @@ func TestDBInfo(t *testing.T) {
 		t.Errorf("Unexpected name %s", info.Name)
 	}
 }
-
-func TestEncodeDocID(t *testing.T) {
-	tests := []struct {
-		Input    string
-		Expected string
-	}{
-		{Input: "foo", Expected: "foo"},
-		{Input: "foo/bar", Expected: "foo%2Fbar"},
-		{Input: "_design/foo", Expected: "_design/foo"},
-		{Input: "_design/foo/bar", Expected: "_design/foo%2Fbar"},
-	}
-	for _, test := range tests {
-		result := encodeDocID(test.Input)
-		if result != test.Expected {
-			t.Errorf("Unexpected encoded DocID from %s\n\tExpected: %s\n\t  Actual: %s\n", test.Input, test.Expected, result)
-		}
-	}
-}

--- a/test/db/put.go
+++ b/test/db/put.go
@@ -98,6 +98,18 @@ func testPut(ctx *kt.Context, client *kivik.Client) {
 			})
 			ctx.CheckError(err)
 		})
+		ctx.Run("HeavilyEscapedID", func(ctx *kt.Context) {
+			ctx.Parallel()
+			doc := map[string]interface{}{
+				"_id":  "foo+bar & spáces ?!*,",
+				"name": "Bob",
+			}
+			err = kt.Retry(func() error {
+				_, err = db.Put(doc["_id"].(string), doc)
+				return err
+			})
+			ctx.CheckError(err)
+		})
 		ctx.Run("SlashInID", func(ctx *kt.Context) {
 			ctx.Parallel()
 			doc := map[string]interface{}{


### PR DESCRIPTION
This is intended as a more complete solution to #60 