### PR TITLE
Pass default options to CreateDB/DestroyDB/DB for tests.

### DIFF
--- a/test/client/alldbs.go
+++ b/test/client/alldbs.go
@@ -28,12 +28,8 @@ func allDBs(ctx *kt.Context) {
 
 func testAllDBsRW(ctx *kt.Context) {
 	admin := ctx.Admin
-	dbName := ctx.TestDBName()
-	defer admin.DestroyDB(context.Background(), dbName)
-	if err := admin.CreateDB(context.Background(), dbName); err != nil {
-		ctx.Errorf("Failed to create test DB '%s': %s", dbName, err)
-		return
-	}
+	dbName := ctx.TestDB()
+	defer admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
 	expected := append(ctx.StringSlice("expected"), dbName)
 	ctx.Run("group", func(ctx *kt.Context) {
 		ctx.RunAdmin(func(ctx *kt.Context) {

--- a/test/client/createdb.go
+++ b/test/client/createdb.go
@@ -25,11 +25,11 @@ func createDB(ctx *kt.Context) {
 func testCreateDB(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
 	dbName := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
-	if !ctx.IsExpectedSuccess(client.CreateDB(context.Background(), dbName)) {
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+	if !ctx.IsExpectedSuccess(client.CreateDB(context.Background(), dbName, ctx.Options("db"))) {
 		return
 	}
 	ctx.Run("Recreate", func(ctx *kt.Context) {
-		ctx.CheckError(client.CreateDB(context.Background(), dbName))
+		ctx.CheckError(client.CreateDB(context.Background(), dbName, ctx.Options("db")))
 	})
 }

--- a/test/client/dbexists.go
+++ b/test/client/dbexists.go
@@ -23,12 +23,8 @@ func dbExists(ctx *kt.Context) {
 		}
 	})
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbName := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbName)
-		if err := ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-			ctx.Errorf("Failed to create test DB: %s", err)
-			return
-		}
+		dbName := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				checkDBExists(ctx, ctx.Admin, dbName)

--- a/test/client/destroydb.go
+++ b/test/client/destroydb.go
@@ -28,15 +28,12 @@ func destroyDB(ctx *kt.Context) {
 func testDestroy(ctx *kt.Context, client *kivik.Client) {
 	ctx.Run("ExistingDB", func(ctx *kt.Context) {
 		ctx.Parallel()
-		dbName := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbName)
-		if err := ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
-		ctx.CheckError(client.DestroyDB(context.Background(), dbName))
+		dbName := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+		ctx.CheckError(client.DestroyDB(context.Background(), dbName, ctx.Options("db")))
 	})
 	ctx.Run("NonExistantDB", func(ctx *kt.Context) {
 		ctx.Parallel()
-		ctx.CheckError(client.DestroyDB(context.Background(), ctx.TestDBName()))
+		ctx.CheckError(client.DestroyDB(context.Background(), ctx.TestDBName(), ctx.Options("db")))
 	})
 }

--- a/test/client/updates.go
+++ b/test/client/updates.go
@@ -51,8 +51,8 @@ func testUpdates(ctx *kt.Context, client *kivik.Client) {
 		eventErrors <- updates.Err()
 		close(eventErrors)
 	}()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err = ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	if err = ctx.Admin.CreateDB(context.Background(), dbname, ctx.Options("db")); err != nil {
 		ctx.Fatalf("Failed to create db: %s", err)
 	}
 	timer := time.NewTimer(maxWait)

--- a/test/db/alldocs.go
+++ b/test/db/alldocs.go
@@ -35,7 +35,7 @@ func testAllDocsRW(ctx *kt.Context) {
 	if err != nil {
 		ctx.Errorf("Failed to set up temp db: %s", err)
 	}
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
 	ctx.Run("group", func(ctx *kt.Context) {
 		ctx.RunAdmin(func(ctx *kt.Context) {
 			doTest(ctx, ctx.Admin, dbName, 0, expected)
@@ -47,11 +47,8 @@ func testAllDocsRW(ctx *kt.Context) {
 }
 
 func setUpAllDocsTest(ctx *kt.Context) (dbName string, docIDs []string, err error) {
-	dbName = ctx.TestDBName()
-	if err = ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-		return dbName, nil, errors.Wrap(err, "failed to create db")
-	}
-	db, err := ctx.Admin.DB(context.Background(), dbName)
+	dbName = ctx.TestDB()
+	db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 	if err != nil {
 		return dbName, nil, errors.Wrap(err, "failed to connect to db")
 	}
@@ -98,7 +95,7 @@ func doTest(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int6
 
 func doTestWithoutDocs(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int64, expected []string) {
 	ctx.Parallel()
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	// Errors may be deferred here, so only return if we actually get
 	// an error.
 	if err != nil && !ctx.IsExpectedSuccess(err) {
@@ -129,7 +126,7 @@ func doTestWithoutDocs(ctx *kt.Context, client *kivik.Client, dbName string, exp
 
 func doTestWithDocs(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int64, expected []string) {
 	ctx.Parallel()
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	// Errors may be deferred here, so only return if we actually get
 	// an error.
 	if err != nil && !ctx.IsExpectedSuccess(err) {

--- a/test/db/bulk.go
+++ b/test/db/bulk.go
@@ -24,16 +24,13 @@ func bulkDocs(ctx *kt.Context) {
 
 func testBulkDocs(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create db: %s", err)
-	}
-	adb, err := ctx.Admin.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	adb, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db as admin: %s", err)
 	}
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db: %s", err)
 	}

--- a/test/db/changes.go
+++ b/test/db/changes.go
@@ -29,12 +29,9 @@ const maxWait = 5 * time.Second
 
 func testChanges(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create db: %s", err)
-	}
-	db, err := client.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("failed to connect to db: %s", err)
 	}

--- a/test/db/compact.go
+++ b/test/db/compact.go
@@ -25,12 +25,9 @@ func compact(ctx *kt.Context) {
 }
 
 func testCompact(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create test db: %s", err)
-	}
-	db, err := client.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db: %s", err)
 	}

--- a/test/db/copy.go
+++ b/test/db/copy.go
@@ -13,12 +13,9 @@ func init() {
 
 func copy(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
-		db, err := ctx.Admin.DB(context.Background(), dbname)
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+		db, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to open db: %s", err)
 		}
@@ -71,7 +68,7 @@ func copy(ctx *kt.Context) {
 func copyTest(ctx *kt.Context, client *kivik.Client, dbname string, source map[string]string) {
 	ctx.Run(source["_id"], func(ctx *kt.Context) {
 		ctx.Parallel()
-		db, err := client.DB(context.Background(), dbname)
+		db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to open db: %s", err)
 		}

--- a/test/db/createIndex.go
+++ b/test/db/createIndex.go
@@ -25,12 +25,9 @@ func createIndex(ctx *kt.Context) {
 }
 
 func testCreateIndex(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create db: %s", err)
-	}
-	db, err := client.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}

--- a/test/db/createdoc.go
+++ b/test/db/createdoc.go
@@ -13,11 +13,8 @@ func init() {
 
 func createDoc(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create test db: %s", err)
-		}
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				ctx.Parallel()
@@ -32,7 +29,7 @@ func createDoc(ctx *kt.Context) {
 }
 
 func testCreate(ctx *kt.Context, client *kivik.Client, dbname string) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to database: %s", err)
 	}

--- a/test/db/delattachment.go
+++ b/test/db/delattachment.go
@@ -13,11 +13,8 @@ func init() {
 
 func delAttachment(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				ctx.Parallel()
@@ -38,7 +35,7 @@ func delAttachment(ctx *kt.Context) {
 }
 
 func testDeleteAttachmentNoDoc(ctx *kt.Context, client *kivik.Client, dbname string) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db")
 	}
@@ -63,12 +60,12 @@ func testDeleteAttachmentsDDoc(ctx *kt.Context, client *kivik.Client, dbname, fi
 
 func doDeleteAttachmentTest(ctx *kt.Context, client *kivik.Client, dbname, docID, filename string) {
 
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db")
 	}
 	ctx.Parallel()
-	adb, err := ctx.Admin.DB(context.Background(), dbname)
+	adb, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}

--- a/test/db/delete.go
+++ b/test/db/delete.go
@@ -30,17 +30,13 @@ type deleteDoc struct {
 
 func testDelete(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
-	dbName := ctx.TestDBName()
-	if err := ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-		ctx.Errorf("Failed to create test db '%s': %s", dbName, err)
-		return
-	}
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
-	admdb, err := ctx.Admin.DB(context.Background(), dbName)
+	dbName := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+	admdb, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 	if err != nil {
 		ctx.Errorf("Failed to connect to db as admin: %s", err)
 	}
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	if err != nil {
 		ctx.Errorf("Failed to connect to db: %s", err)
 		return

--- a/test/db/delindex.go
+++ b/test/db/delindex.go
@@ -25,19 +25,16 @@ func delindex(ctx *kt.Context) {
 }
 
 func testDelIndex(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create db: %s", err)
-	}
-	dba, err := ctx.Admin.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	dba, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db as admin: %s", err)
 	}
 	if err = dba.CreateIndex(context.Background(), "foo", "bar", `{"fields":["foo"]}`); err != nil {
 		ctx.Fatalf("Failed to create index: %s", err)
 	}
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}

--- a/test/db/find.go
+++ b/test/db/find.go
@@ -35,7 +35,7 @@ func testFindRW(ctx *kt.Context) {
 	if err != nil {
 		ctx.Errorf("Failed to set up temp db: %s", err)
 	}
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
 	ctx.Run("group", func(ctx *kt.Context) {
 		ctx.RunAdmin(func(ctx *kt.Context) {
 			doFindTest(ctx, ctx.Admin, dbName, 0, expected)
@@ -47,11 +47,8 @@ func testFindRW(ctx *kt.Context) {
 }
 
 func setUpFindTest(ctx *kt.Context) (dbName string, docIDs []string, err error) {
-	dbName = ctx.TestDBName()
-	if err = ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-		return dbName, nil, errors.Wrap(err, "failed to create db")
-	}
-	db, err := ctx.Admin.DB(context.Background(), dbName)
+	dbName = ctx.TestDB()
+	db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 	if err != nil {
 		return dbName, nil, errors.Wrap(err, "failed to connect to db")
 	}
@@ -89,7 +86,7 @@ func testFind(ctx *kt.Context, client *kivik.Client) {
 
 func doFindTest(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int64, expected []string) {
 	ctx.Parallel()
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	// Errors may be deferred here, so only return if we actually get
 	// an error.
 	if err != nil && !ctx.IsExpectedSuccess(err) {

--- a/test/db/flush.go
+++ b/test/db/flush.go
@@ -25,7 +25,7 @@ func flushTest(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
 	for _, dbName := range ctx.MustStringSlice("databases") {
 		ctx.Run(dbName, func(ctx *kt.Context) {
-			db, err := client.DB(context.Background(), dbName)
+			db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 			if !ctx.IsExpectedSuccess(err) {
 				return
 			}

--- a/test/db/get.go
+++ b/test/db/get.go
@@ -21,12 +21,9 @@ type testDoc struct {
 
 func get(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbName := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbName)
-		if err := ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-			ctx.Fatalf("Failed to create test db: %s", err)
-		}
-		db, err := ctx.Admin.DB(context.Background(), dbName)
+		dbName := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+		db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to connect to test db: %s", err)
 		}
@@ -65,7 +62,7 @@ func get(ctx *kt.Context) {
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				ctx.Parallel()
-				db, err := ctx.Admin.DB(context.Background(), dbName)
+				db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 				if !ctx.IsExpectedSuccess(err) {
 					return
 				}
@@ -76,7 +73,7 @@ func get(ctx *kt.Context) {
 			})
 			ctx.RunNoAuth(func(ctx *kt.Context) {
 				ctx.Parallel()
-				db, err := ctx.NoAuth.DB(context.Background(), dbName)
+				db, err := ctx.NoAuth.DB(context.Background(), dbName, ctx.Options("db"))
 				if !ctx.IsExpectedSuccess(err) {
 					return
 				}

--- a/test/db/getattachment.go
+++ b/test/db/getattachment.go
@@ -13,12 +13,9 @@ func init() {
 
 func getAttachment(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
-		adb, err := ctx.Admin.DB(context.Background(), dbname)
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+		adb, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to open db: %s", err)
 		}
@@ -69,7 +66,7 @@ func getAttachment(ctx *kt.Context) {
 func testGetAttachments(ctx *kt.Context, client *kivik.Client, dbname, docID, filename string) {
 	ctx.Run(docID+"/"+filename, func(ctx *kt.Context) {
 		ctx.Parallel()
-		db, err := client.DB(context.Background(), dbname)
+		db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to connect to db")
 		}

--- a/test/db/getattachmentmeta.go
+++ b/test/db/getattachmentmeta.go
@@ -13,12 +13,9 @@ func init() {
 
 func getAttachmentMeta(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
-		adb, err := ctx.Admin.DB(context.Background(), dbname)
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+		adb, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to open db: %s", err)
 		}
@@ -69,7 +66,7 @@ func getAttachmentMeta(ctx *kt.Context) {
 func testGetAttachmentMeta(ctx *kt.Context, client *kivik.Client, dbname, docID, filename string) {
 	ctx.Run(docID+"/"+filename, func(ctx *kt.Context) {
 		ctx.Parallel()
-		db, err := client.DB(context.Background(), dbname)
+		db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to connect to db")
 		}

--- a/test/db/getindexes.go
+++ b/test/db/getindexes.go
@@ -46,12 +46,9 @@ func roGetIndexesTests(ctx *kt.Context, client *kivik.Client) {
 }
 
 func rwGetIndexesTests(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create db: %s", err)
-	}
-	dba, err := ctx.Admin.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	dba, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db as admin: %s", err)
 	}
@@ -74,7 +71,7 @@ func rwGetIndexesTests(ctx *kt.Context, client *kivik.Client) {
 }
 
 func testGetIndexes(ctx *kt.Context, client *kivik.Client, dbname string, expected interface{}) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}

--- a/test/db/info.go
+++ b/test/db/info.go
@@ -35,12 +35,9 @@ func dbInfo(ctx *kt.Context) {
 }
 
 func rwTests(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create test db: %s", err)
-	}
-	db, err := ctx.Admin.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	db, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db: %s", err)
 	}
@@ -71,7 +68,7 @@ func roTests(ctx *kt.Context, client *kivik.Client) {
 }
 
 func testDBInfo(ctx *kt.Context, client *kivik.Client, dbname string, docCount int64) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	// Check against the same status for connecting, and db.Info() later, because
 	// where the error might occur is backend-specific.
 	var info *kivik.DBInfo

--- a/test/db/put.go
+++ b/test/db/put.go
@@ -24,10 +24,9 @@ func put(ctx *kt.Context) {
 
 func testPut(ctx *kt.Context, client *kivik.Client) {
 	ctx.Parallel()
-	dbName := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
-	_ = ctx.Admin.CreateDB(context.Background(), dbName)
-	db, e := client.DB(context.Background(), dbName)
+	dbName := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+	db, e := client.DB(context.Background(), dbName, ctx.Options("db"))
 	if !ctx.IsExpectedSuccess(e) {
 		return
 	}

--- a/test/db/putattachment.go
+++ b/test/db/putattachment.go
@@ -16,11 +16,8 @@ func init() {
 
 func putAttachment(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				ctx.Parallel()
@@ -35,11 +32,11 @@ func putAttachment(ctx *kt.Context) {
 }
 
 func testPutAttachment(ctx *kt.Context, client *kivik.Client, dbname string) {
-	db, e := client.DB(context.Background(), dbname)
+	db, e := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if e != nil {
 		ctx.Fatalf("Failed to open db: %s", e)
 	}
-	adb, e2 := ctx.Admin.DB(context.Background(), dbname)
+	adb, e2 := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 	if e2 != nil {
 		ctx.Fatalf("Failed to open admin db: %s", e2)
 	}

--- a/test/db/query.go
+++ b/test/db/query.go
@@ -29,7 +29,7 @@ func testQueryRW(ctx *kt.Context) {
 	if err != nil {
 		ctx.Errorf("Failed to set up temp db: %s", err)
 	}
-	defer ctx.Admin.DestroyDB(context.Background(), dbName)
+	defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
 	ctx.Run("group", func(ctx *kt.Context) {
 		ctx.RunAdmin(func(ctx *kt.Context) {
 			doQueryTest(ctx, ctx.Admin, dbName, 0, expected)
@@ -55,11 +55,8 @@ var ddoc = map[string]interface{}{
 }
 
 func setUpQueryTest(ctx *kt.Context) (dbName string, docIDs []string, err error) {
-	dbName = ctx.TestDBName()
-	if err = ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-		return dbName, nil, errors.Wrap(err, "failed to create db")
-	}
-	db, err := ctx.Admin.DB(context.Background(), dbName)
+	dbName = ctx.TestDB()
+	db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 	if err != nil {
 		return dbName, nil, errors.Wrap(err, "failed to connect to db")
 	}
@@ -99,7 +96,7 @@ func doQueryTest(ctx *kt.Context, client *kivik.Client, dbName string, expOffset
 
 func doQueryTestWithoutDocs(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int64, expected []string) {
 	ctx.Parallel()
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	// Errors may be deferred here, so only return if we actually get
 	// an error.
 	if err != nil && !ctx.IsExpectedSuccess(err) {
@@ -130,7 +127,7 @@ func doQueryTestWithoutDocs(ctx *kt.Context, client *kivik.Client, dbName string
 
 func doQueryTestWithDocs(ctx *kt.Context, client *kivik.Client, dbName string, expOffset int64, expected []string) {
 	ctx.Parallel()
-	db, err := client.DB(context.Background(), dbName)
+	db, err := client.DB(context.Background(), dbName, ctx.Options("db"))
 	// Errors may be deferred here, so only return if we actually get
 	// an error.
 	if err != nil && !ctx.IsExpectedSuccess(err) {

--- a/test/db/rev.go
+++ b/test/db/rev.go
@@ -14,12 +14,9 @@ func init() {
 
 func rev(ctx *kt.Context) {
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbName := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbName)
-		if err := ctx.Admin.CreateDB(context.Background(), dbName); err != nil {
-			ctx.Fatalf("Failed to create test db: %s", err)
-		}
-		db, err := ctx.Admin.DB(context.Background(), dbName)
+		dbName := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbName, ctx.Options("db"))
+		db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to connect to test db: %s", err)
 		}
@@ -53,7 +50,7 @@ func rev(ctx *kt.Context) {
 		ctx.Run("group", func(ctx *kt.Context) {
 			ctx.RunAdmin(func(ctx *kt.Context) {
 				ctx.Parallel()
-				db, err := ctx.Admin.DB(context.Background(), dbName)
+				db, err := ctx.Admin.DB(context.Background(), dbName, ctx.Options("db"))
 				if !ctx.IsExpectedSuccess(err) {
 					return
 				}
@@ -64,7 +61,7 @@ func rev(ctx *kt.Context) {
 			})
 			ctx.RunNoAuth(func(ctx *kt.Context) {
 				ctx.Parallel()
-				db, err := ctx.NoAuth.DB(context.Background(), dbName)
+				db, err := ctx.NoAuth.DB(context.Background(), dbName, ctx.Options("db"))
 				if !ctx.IsExpectedSuccess(err) {
 					return
 				}

--- a/test/db/security.go
+++ b/test/db/security.go
@@ -47,12 +47,9 @@ func security(ctx *kt.Context) {
 		}
 	})
 	ctx.RunRW(func(ctx *kt.Context) {
-		dbname := ctx.TestDBName()
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-			ctx.Fatalf("Failed to create db: %s", err)
-		}
-		db, err := ctx.Admin.DB(context.Background(), dbname)
+		dbname := ctx.TestDB()
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+		db, err := ctx.Admin.DB(context.Background(), dbname, ctx.Options("db"))
 		if err != nil {
 			ctx.Fatalf("Failed to open db: %s", err)
 		}
@@ -90,10 +87,10 @@ func testSetSecurityTests(ctx *kt.Context, client *kivik.Client) {
 	ctx.Run("Exists", func(ctx *kt.Context) {
 		ctx.Parallel()
 		dbname := ctx.TestDBName()
-		if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
+		if err := ctx.Admin.CreateDB(context.Background(), dbname, ctx.Options("db")); err != nil {
 			ctx.Fatalf("Failed to create db: %s", err)
 		}
-		defer ctx.Admin.DestroyDB(context.Background(), dbname)
+		defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
 		testSetSecurity(ctx, client, dbname)
 	})
 	ctx.Run("NotExists", func(ctx *kt.Context) {
@@ -104,7 +101,7 @@ func testSetSecurityTests(ctx *kt.Context, client *kivik.Client) {
 }
 
 func testSetSecurity(ctx *kt.Context, client *kivik.Client, dbname string) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}
@@ -115,7 +112,7 @@ func testSetSecurity(ctx *kt.Context, client *kivik.Client, dbname string) {
 }
 
 func testGetSecurity(ctx *kt.Context, client *kivik.Client, dbname string, expected *kivik.Security) {
-	db, err := client.DB(context.Background(), dbname)
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to open db: %s", err)
 	}

--- a/test/db/viewcleanup.go
+++ b/test/db/viewcleanup.go
@@ -25,12 +25,9 @@ func viewCleanup(ctx *kt.Context) {
 }
 
 func testViewCleanup(ctx *kt.Context, client *kivik.Client) {
-	dbname := ctx.TestDBName()
-	defer ctx.Admin.DestroyDB(context.Background(), dbname)
-	if err := ctx.Admin.CreateDB(context.Background(), dbname); err != nil {
-		ctx.Fatalf("Failed to create test db: %s", err)
-	}
-	db, err := client.DB(context.Background(), dbname)
+	dbname := ctx.TestDB()
+	defer ctx.Admin.DestroyDB(context.Background(), dbname, ctx.Options("db"))
+	db, err := client.DB(context.Background(), dbname, ctx.Options("db"))
 	if err != nil {
 		ctx.Fatalf("Failed to connect to db: %s", err)
 	}

--- a/test/kt/config.go
+++ b/test/kt/config.go
@@ -22,12 +22,21 @@ func name(t *testing.T) string {
 // get looks for the requested key at the current level, and if not found it
 // looks at the parent key.
 func (c SuiteConfig) get(name, key string) interface{} {
-	v, ok := c[name+"."+key]
+	var k string
+	if name == "" {
+		k = key
+	} else {
+		k = name + "." + key
+	}
+	v, ok := c[k]
 	if ok {
 		return v
 	}
-	if !strings.Contains(name, "/") {
+	if name == "" {
 		return nil
+	}
+	if !strings.Contains(name, "/") {
+		return c.get("", key)
 	}
 	// Try the parent
 	return c.get(name[0:strings.LastIndex(name, "/")], key)

--- a/test/kt/kt.go
+++ b/test/kt/kt.go
@@ -136,6 +136,13 @@ func (c *Context) Interface(key string) interface{} {
 	return c.Config.get(name(c.T), key)
 }
 
+// Options returns an options map value.
+func (c *Context) Options(key string) map[string]interface{} {
+	i := c.Config.get(name(c.T), key)
+	o, _ := i.(map[string]interface{})
+	return o
+}
+
 // MustInterface returns an interface{} from the config, or fails if the value is unset.
 func (c *Context) MustInterface(key string) interface{} {
 	c.MustBeSet(key)
@@ -184,6 +191,15 @@ func init() {
 
 // TestDBPrefix is used to prefix temporary database names during tests.
 const TestDBPrefix = "kivik$"
+
+// TestDB creates a test database and returns its name.
+func (c *Context) TestDB() string {
+	dbname := c.TestDBName()
+	if err := c.Admin.CreateDB(context.Background(), dbname, c.Options("db")); err != nil {
+		c.Fatalf("Failed to create database: %s", err)
+	}
+	return dbname
+}
 
 // TestDBName generates a randomized string suitable for a database name for
 // testing.

--- a/test/pouchdb.go
+++ b/test/pouchdb.go
@@ -5,10 +5,13 @@ package test
 import (
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/test/kt"
+	"github.com/gopherjs/gopherjs/js"
 )
 
 func init() {
 	RegisterSuite(SuitePouchLocal, kt.SuiteConfig{
+		"db": map[string]interface{}{"db": js.Global.Call("require", "memdown")},
+
 		"PreCleanup.skip": true,
 
 		// Features which are not supported by PouchDB


### PR DESCRIPTION
This to enforce memdown for PouchDB tests.

Fixes #78