### PR TITLE
Attempt to solve data race in http library

### DIFF
--- a/driver/couchdb/chttp/chttp.go
+++ b/driver/couchdb/chttp/chttp.go
@@ -175,21 +175,7 @@ func (c *Client) DoReq(ctx context.Context, method, path string, opts *Options) 
 	fixPath(req, path)
 	setHeaders(req, opts)
 
-	// call Do in a loop to check for errors that probably shouldn't happen.
-	// A work-around for the possible issue https://github.com/golang/go/issues/19943
-	var resp *http.Response
-	for i := 0; i < 3; i++ {
-		resp, err = c.Do(req)
-		if err != nil {
-			msg := err.Error()
-			if strings.HasSuffix(msg, ": EOF") ||
-				strings.HasSuffix(msg, ": http: server closed idle connection") {
-				continue
-			}
-		}
-		return resp, err
-	}
-	return resp, err
+	return c.Do(req)
 }
 
 // fixPath sets the request's URL.RawPath to work with escaped '/' chars in

--- a/test/kt/kt.go
+++ b/test/kt/kt.go
@@ -272,6 +272,8 @@ func Retry(fn func() error) error {
 			msg := strings.TrimSpace(err.Error())
 			if strings.HasSuffix(msg, "io: read/write on closed pipe") ||
 				strings.HasSuffix(msg, "write: broken pipe") ||
+				strings.HasSuffix(msg, ": EOF") ||
+				strings.HasSuffix(msg, ": http: server closed idle connection") ||
 				strings.HasSuffix(msg, "read: connection reset by peer") {
 				fmt.Printf("Retrying after error: %s\n", err)
 				continue


### PR DESCRIPTION
I believe this race is the result of re-using the http request in retries.