### PR TITLE
Ignore timestamps from Flush()

### DIFF
--- a/db.go
+++ b/db.go
@@ -3,7 +3,6 @@ package kivik
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/flimzy/kivik/driver"
 )
@@ -72,15 +71,13 @@ func (db *DB) Delete(ctx context.Context, docID, rev string) (newRev string, err
 }
 
 // Flush requests a flush of disk cache to disk or other permanent storage.
-// The response a timestamp when the database backend opened the storage
-// backend.
 //
 // See http://docs.couchdb.org/en/2.0.0/api/database/compact.html#db-ensure-full-commit
-func (db *DB) Flush(ctx context.Context) (time.Time, error) {
+func (db *DB) Flush(ctx context.Context) error {
 	if flusher, ok := db.driverDB.(driver.DBFlusher); ok {
 		return flusher.Flush(ctx)
 	}
-	return time.Time{}, ErrNotImplemented
+	return ErrNotImplemented
 }
 
 // DBInfo is a struct of information about a database instance. Not all fields

--- a/driver/couchdb/db.go
+++ b/driver/couchdb/db.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/driver"
@@ -169,12 +168,9 @@ func (d *db) Delete(ctx context.Context, docID, rev string) (string, error) {
 	return chttp.GetRev(resp)
 }
 
-func (d *db) Flush(ctx context.Context) (time.Time, error) {
-	result := struct {
-		T int64 `json:"instance_start_time,string"`
-	}{}
-	_, err := d.Client.DoJSON(ctx, kivik.MethodPost, d.path("/_ensure_full_commit", nil), nil, &result)
-	return time.Unix(0, 0).Add(time.Duration(result.T) * time.Microsecond), err
+func (d *db) Flush(ctx context.Context) error {
+	_, err := d.Client.DoError(ctx, kivik.MethodPost, d.path("/_ensure_full_commit", nil), nil)
+	return err
 }
 
 func (d *db) Info(ctx context.Context) (*driver.DBInfo, error) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"time"
 )
 
 // Driver is the interface that must be implemented by a database driver.
@@ -193,11 +192,9 @@ type Rever interface {
 // permanent storage.
 type DBFlusher interface {
 	// Flush requests a flush of disk cache to disk or other permanent storage.
-	// The response a timestamp when the database backend opened the storage
-	// backend.
 	//
 	// See http://docs.couchdb.org/en/2.0.0/api/database/compact.html#db-ensure-full-commit
-	Flush(ctx context.Context) (time.Time, error)
+	Flush(ctx context.Context) error
 }
 
 // Copier is an optional interface that may be implemented by a DB.

--- a/serve/flush.go
+++ b/serve/flush.go
@@ -3,7 +3,6 @@ package serve
 import (
 	"encoding/json"
 	"net/http"
-	"time"
 )
 
 func flush(w http.ResponseWriter, r *http.Request) error {
@@ -13,13 +12,12 @@ func flush(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	ts, err := db.Flush(r.Context())
-	if err != nil {
+	if err = db.Flush(r.Context()); err != nil {
 		return err
 	}
 	w.Header().Set("Content-Type", typeJSON)
 	return json.NewEncoder(w).Encode(map[string]interface{}{
-		"instance_start_time": int64(ts.Sub(time.Unix(0, 0)).Seconds() * 1e6),
+		"instance_start_time": 0,
 		"ok": true,
 	})
 }

--- a/test/cloudant.go
+++ b/test/cloudant.go
@@ -87,13 +87,12 @@ func init() {
 
 		"Put/RW/NoAuth/Create.status": kivik.StatusUnauthorized,
 
-		"Flush.databases":                           []string{"_users", "chicken", "_duck"},
-		"Flush/Admin/chicken/DoFlush.status":        kivik.StatusNotFound,
-		"Flush/Admin/_duck/DoFlush.status":          kivik.StatusForbidden,
-		"Flush/NoAuth/chicken/DoFlush.status":       kivik.StatusNotFound,
-		"Flush/NoAuth/_users/DoFlush.status":        kivik.StatusUnauthorized,
-		"Flush/Admin/_users/DoFlush/Timestamp.skip": true, // Cloudant always sets the timestamp to 0
-		"Flush/NoAuth/_duck/DoFlush.status":         kivik.StatusUnauthorized,
+		"Flush.databases":                     []string{"_users", "chicken", "_duck"},
+		"Flush/Admin/chicken/DoFlush.status":  kivik.StatusNotFound,
+		"Flush/Admin/_duck/DoFlush.status":    kivik.StatusForbidden,
+		"Flush/NoAuth/chicken/DoFlush.status": kivik.StatusNotFound,
+		"Flush/NoAuth/_users/DoFlush.status":  kivik.StatusUnauthorized,
+		"Flush/NoAuth/_duck/DoFlush.status":   kivik.StatusUnauthorized,
 
 		"Delete/RW/Admin/group/MissingDoc.status":       kivik.StatusNotFound,
 		"Delete/RW/Admin/group/InvalidRevFormat.status": kivik.StatusBadRequest,

--- a/test/couchdb20.go
+++ b/test/couchdb20.go
@@ -76,13 +76,11 @@ func init() {
 		"Rev/RW/group/Admin/bogus.status":  kivik.StatusNotFound,
 		"Rev/RW/group/NoAuth/bogus.status": kivik.StatusNotFound,
 
-		"Flush.databases":                            []string{"_users", "chicken", "_duck"},
-		"Flush/NoAuth/chicken/DoFlush.status":        kivik.StatusNotFound,
-		"Flush/Admin/chicken/DoFlush.status":         kivik.StatusNotFound,
-		"Flush/Admin/_users/DoFlush/Timestamp.skip":  true, // CouchDB 2.0 always returns 0?
-		"Flush/Admin/_duck/DoFlush.status":           kivik.StatusNotFound,
-		"Flush/NoAuth/_users/DoFlush/Timestamp.skip": true, // CouchDB 2.0 always returns 0?
-		"Flush/NoAuth/_duck/DoFlush.status":          kivik.StatusUnauthorized,
+		"Flush.databases":                     []string{"_users", "chicken", "_duck"},
+		"Flush/NoAuth/chicken/DoFlush.status": kivik.StatusNotFound,
+		"Flush/Admin/chicken/DoFlush.status":  kivik.StatusNotFound,
+		"Flush/Admin/_duck/DoFlush.status":    kivik.StatusNotFound,
+		"Flush/NoAuth/_duck/DoFlush.status":   kivik.StatusUnauthorized,
 
 		"Delete/RW/Admin/group/MissingDoc.status":        kivik.StatusNotFound,
 		"Delete/RW/Admin/group/InvalidRevFormat.status":  kivik.StatusBadRequest,

--- a/test/db/flush.go
+++ b/test/db/flush.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"time"
 
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/test/kt"
@@ -30,18 +29,10 @@ func flushTest(ctx *kt.Context, client *kivik.Client) {
 				return
 			}
 			ctx.Run("DoFlush", func(ctx *kt.Context) {
-				ts, err := db.Flush(context.Background())
+				err := db.Flush(context.Background())
 				if !ctx.IsExpectedSuccess(err) {
 					return
 				}
-				ctx.Run("Timestamp", func(ctx *kt.Context) {
-					if !time.Now().After(ts) {
-						ctx.Errorf("Timestamp in the future: %s", ts)
-					}
-					if !ts.After(time.Now().Add(-time.Hour * 9000)) { // About a year; just to make sure we're within an order of magnitude
-						ctx.Errorf("Timestamp is in the distant past: %s", ts)
-					}
-				})
 			})
 		})
 	}


### PR DESCRIPTION
CouchDB 2.0 no longer supports this, and it seems rather worthless anyway,
so just get rid of it.

Fixes #87