### PR TITLE
Switch single-document Get() to return a Row

### DIFF
--- a/authdb/couchauth/couchauth_test.go
+++ b/authdb/couchauth/couchauth_test.go
@@ -41,8 +41,6 @@ func TestCouchAuth(t *testing.T) {
 		Roles:    []string{"coolguy"},
 		Password: "abc123",
 	}
-	// Courtesy flush
-	kt.DeleteUser(db, user.ID, t)
 	rev, e := db.Put(context.Background(), user.ID, user)
 	if e != nil {
 		t.Fatalf("Failed to create user: %s", e)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -82,7 +82,7 @@ type DB interface {
 	AllDocs(ctx context.Context, options map[string]interface{}) (Rows, error)
 	// Get fetches the requested document from the database, and unmarshals it
 	// into doc.
-	Get(ctx context.Context, docID string, doc interface{}, options map[string]interface{}) error
+	Get(ctx context.Context, docID string, options map[string]interface{}) (json.RawMessage, error)
 	// CreateDoc creates a new doc, with a server-generated ID.
 	CreateDoc(ctx context.Context, doc interface{}) (docID, rev string, err error)
 	// Put writes the document in the database.

--- a/driver/fs/db.go
+++ b/driver/fs/db.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/flimzy/kivik"
@@ -23,9 +24,9 @@ func (d *db) Query(ctx context.Context, ddoc, view string, opts map[string]inter
 	return nil, kivik.ErrNotImplemented
 }
 
-func (d *db) Get(_ context.Context, docID string, doc interface{}, opts map[string]interface{}) error {
+func (d *db) Get(_ context.Context, docID string, opts map[string]interface{}) (json.RawMessage, error) {
 	// FIXME: Unimplemented
-	return kivik.ErrNotImplemented
+	return nil, kivik.ErrNotImplemented
 }
 
 func (d *db) CreateDoc(_ context.Context, doc interface{}) (docID, rev string, err error) {

--- a/driver/memory/db.go
+++ b/driver/memory/db.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/flimzy/kivik"
@@ -34,9 +35,9 @@ func (d *db) Query(ctx context.Context, ddoc, view string, opts map[string]inter
 	return nil, kivik.ErrNotImplemented
 }
 
-func (d *db) Get(_ context.Context, docID string, doc interface{}, opts map[string]interface{}) error {
+func (d *db) Get(_ context.Context, docID string, opts map[string]interface{}) (json.RawMessage, error) {
 	// FIXME: Unimplemented
-	return kivik.ErrNotImplemented
+	return nil, kivik.ErrNotImplemented
 }
 
 func (d *db) CreateDoc(_ context.Context, doc interface{}) (docID, rev string, err error) {

--- a/driver/pouchdb/db.go
+++ b/driver/pouchdb/db.go
@@ -43,12 +43,8 @@ func (d *db) Query(ctx context.Context, ddoc, view string, options map[string]in
 	}, nil
 }
 
-func (d *db) Get(ctx context.Context, docID string, doc interface{}, options map[string]interface{}) error {
-	body, err := d.db.Get(ctx, docID, options)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(body, &doc)
+func (d *db) Get(ctx context.Context, docID string, options map[string]interface{}) (json.RawMessage, error) {
+	return d.db.Get(ctx, docID, options)
 }
 
 func (d *db) CreateDoc(ctx context.Context, doc interface{}) (docID, rev string, err error) {

--- a/driver/proxy/proxy.go
+++ b/driver/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/flimzy/kivik"
@@ -79,8 +80,14 @@ func (d *db) Query(ctx context.Context, ddoc, view string, opts map[string]inter
 	return &rows{kivikRows}, nil
 }
 
-func (d *db) Get(ctx context.Context, id string, i interface{}, opts map[string]interface{}) error {
-	return d.DB.Get(ctx, id, i, opts)
+func (d *db) Get(ctx context.Context, id string, opts map[string]interface{}) (json.RawMessage, error) {
+	row, err := d.DB.Get(ctx, id, opts)
+	if err != nil {
+		return nil, err
+	}
+	var raw json.RawMessage
+	err = row.ScanDoc(&raw)
+	return raw, err
 }
 
 func (d *db) Info(ctx context.Context) (*driver.DBInfo, error) {

--- a/test/db/copy.go
+++ b/test/db/copy.go
@@ -90,9 +90,13 @@ func copyTest(ctx *kt.Context, client *kivik.Client, dbname string, source map[s
 			if _, err := db.Copy(context.Background(), targetID2, targetID, kivik.Options{"rev": rev}); err != nil {
 				ctx.Fatalf("Failed to copy doc with rev option: %s", err)
 			}
-			var readCopy map[string]string
-			if err := db.Get(context.Background(), targetID2, &readCopy); err != nil {
+			row, err := db.Get(context.Background(), targetID2)
+			if err != nil {
 				ctx.Fatalf("Failed to read copy: %s", err)
+			}
+			var readCopy map[string]string
+			if err = row.ScanDoc(&readCopy); err != nil {
+				ctx.Fatalf("Failed to scan copy: %s", err)
 			}
 			if readCopy["name"] != "Robert" {
 				ctx.Errorf("Copy-with-rev failed. Name = %s, expected %s", readCopy["name"], "Robert")

--- a/test/db/delattachment.go
+++ b/test/db/delattachment.go
@@ -86,8 +86,7 @@ func doDeleteAttachmentTest(ctx *kt.Context, client *kivik.Client, dbname, docID
 	if !ctx.IsExpectedSuccess(err) {
 		return
 	}
-	var x struct{}
-	if err := db.Get(context.Background(), docID, &x, map[string]interface{}{"rev": rev}); err != nil {
+	if _, err = db.Get(context.Background(), docID, map[string]interface{}{"rev": rev}); err != nil {
 		ctx.Fatalf("Failed to get deleted doc: %s", err)
 	}
 }

--- a/test/db/get.go
+++ b/test/db/get.go
@@ -89,10 +89,13 @@ func get(ctx *kt.Context) {
 func testGet(ctx *kt.Context, db *kivik.DB, expectedDoc *testDoc) {
 	ctx.Run(expectedDoc.ID, func(ctx *kt.Context) {
 		ctx.Parallel()
-		doc := &testDoc{}
-		err := db.Get(context.Background(), expectedDoc.ID, &doc)
+		row, err := db.Get(context.Background(), expectedDoc.ID)
 		if !ctx.IsExpectedSuccess(err) {
 			return
+		}
+		doc := &testDoc{}
+		if err = row.ScanDoc(&doc); err != nil {
+			ctx.Fatalf("Failed to scan doc: %s", err)
 		}
 		if d := diff.AsJSON(expectedDoc, doc); d != "" {
 			ctx.Errorf("Fetched document not as expected:\n%s\n", d)

--- a/test/db/rev.go
+++ b/test/db/rev.go
@@ -81,9 +81,13 @@ func testRev(ctx *kt.Context, db *kivik.DB, expectedDoc *testDoc) {
 		if !ctx.IsExpectedSuccess(err) {
 			return
 		}
-		doc := &testDoc{}
-		if err = db.Get(context.Background(), expectedDoc.ID, &doc); err != nil {
+		row, err := db.Get(context.Background(), expectedDoc.ID)
+		if err != nil {
 			ctx.Fatalf("Failed to get doc: %s", err)
+		}
+		doc := &testDoc{}
+		if err = row.ScanDoc(&doc); err != nil {
+			ctx.Fatalf("Failed to scan doc: %s\n", err)
 		}
 		if strings.HasPrefix(expectedDoc.ID, "_local/") {
 			// Revisions are meaningless for _local docs

--- a/test/kt/kt.go
+++ b/test/kt/kt.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/driver/couchdb/chttp"
-	"github.com/flimzy/kivik/errors"
 )
 
 // Context is a collection of client connections with different security access.
@@ -258,24 +257,6 @@ func (c *Context) Errorf(format string, args ...interface{}) {
 // Parallel is a wrapper around t.Parallel()
 func (c *Context) Parallel() {
 	c.T.Parallel()
-}
-
-// DeleteUser deletes a user.
-func DeleteUser(db *kivik.DB, username string, t *testing.T) {
-	name := "org.couchdb.user:" + username
-	u := struct {
-		Rev string `json:"_rev"`
-	}{}
-	err := db.Get(context.Background(), name, &u)
-	if errors.StatusCode(err) == kivik.StatusNotFound {
-		return
-	}
-	if err != nil {
-		t.Fatalf("Failed to fetch user '%s' for deleting: %s", username, err)
-	}
-	if _, err = db.Delete(context.Background(), name, u.Rev); err != nil {
-		t.Fatalf("Failed to delete user '%s': %s", username, err)
-	}
 }
 
 // Retry will try an operation up to 3 times, in case of one of the following


### PR DESCRIPTION
This copies sql's behavior, but most important, it means Get() doesn't
accept both input _and_ output parameters.

Fixes #86 