### PR TITLE
Move attachment instantiation inside retry loop

### DIFF
--- a/test/db/putattachment.go
+++ b/test/db/putattachment.go
@@ -61,8 +61,8 @@ func testPutAttachment(ctx *kt.Context, client *kivik.Client, dbname string) {
 	ctx.Run("Create", func(ctx *kt.Context) {
 		ctx.Parallel()
 		docID := ctx.TestDBName()
-		att := kivik.NewAttachment("test.txt", "text/plain", stringReadCloser("test content"))
 		err := kt.Retry(func() error {
+			att := kivik.NewAttachment("test.txt", "text/plain", stringReadCloser("test content"))
 			_, err := db.PutAttachment(context.Background(), docID, "", att)
 			return err
 		})


### PR DESCRIPTION
... so we don't try to re-use an io.Reader

Fixes #110 