### PR TITLE
Fix handling of certain NodeJS errors

### DIFF
--- a/driver/pouchdb/bindings/errors.go
+++ b/driver/pouchdb/bindings/errors.go
@@ -32,17 +32,6 @@ func NewPouchError(o *js.Object) error {
 		msg = o.Get("reason").String()
 	case o.Get("message") != js.Undefined:
 		msg = o.Get("message").String()
-	case o.Get("errno") != js.Undefined:
-		switch o.Get("errno").String() {
-		case "ECONNREFUSED":
-			msg = "connection refused"
-		case "ECONNRESET":
-			msg = "connection reset by peer"
-		case "EPIPE":
-			msg = "broken pipe"
-		case "ETIMEDOUT", "ESOCKETTIMEDOUT":
-			msg = "operation timed out"
-		}
 	default:
 		if jsbuiltin.InstanceOf(o, js.Global.Get("Error")) {
 			return errors.Status(status, o.Get("message").String())
@@ -53,9 +42,21 @@ func NewPouchError(o *js.Object) error {
 		err = o.Get("name").String()
 	case o.Get("error") != js.Undefined:
 		err = o.Get("error").String()
-	case o.Get("syscall") != js.Undefined:
-		err = o.Get("syscall").String()
 	}
+
+	if msg == "" && o.Get("errno") != js.Undefined {
+		switch o.Get("errno").String() {
+		case "ECONNREFUSED":
+			msg = "connection refused"
+		case "ECONNRESET":
+			msg = "connection reset by peer"
+		case "EPIPE":
+			msg = "broken pipe"
+		case "ETIMEDOUT", "ESOCKETTIMEDOUT":
+			msg = "operation timed out"
+		}
+	}
+
 	return &pouchError{
 		Err:     err,
 		Message: msg,

--- a/driver/pouchdb/bindings/errors_test.go
+++ b/driver/pouchdb/bindings/errors_test.go
@@ -36,18 +36,27 @@ func TestNewPouchError(t *testing.T) {
 		},
 		{
 			Name: "ECONNREFUSED",
-			Object: func() *js.Object {
-				o := js.Global.Get("Object").New()
-				o.Set("code", "ECONNREFUSED")
-				o.Set("errno", "ECONNREFUSED")
-				o.Set("syscall", "connect")
-				o.Set("address", "127.0.0.1")
-				o.Set("port", "5984")
-				o.Set("status", "500")
-				return o
-			}(),
+			Object: js.Global.Call("ReconstitutePouchError", `{
+                "code":    "ECONNREFUSED",
+                "errno":   "ECONNREFUSED",
+                "syscall": "connect",
+                "address": "127.0.0.1",
+                "port":    5984,
+                "status":  500,
+                "result": {
+                        "ok": false,
+                        "start_time": "Tue May 16 2017 08:26:31 GMT+0000 (UTC)",
+                        "docs_read": 0,
+                        "docs_written": 0,
+                        "doc_write_failures": 0,
+                        "errors": [],
+                        "status": "aborting",
+                        "end_time": "Tue May 16 2017 08:26:31 GMT+0000 (UTC)",
+                        "last_seq": 0
+                    }
+                }`),
 			ExpectedStatus: 500,
-			Expected:       "connect: connection refused",
+			Expected:       "Error: connection refused",
 		},
 	}
 	for _, test := range tests {

--- a/driver/pouchdb/bindings/errors_test.go
+++ b/driver/pouchdb/bindings/errors_test.go
@@ -1,0 +1,74 @@
+package bindings
+
+import (
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+type statuser interface {
+	StatusCode() int
+}
+
+func TestNewPouchError(t *testing.T) {
+	type npeTest struct {
+		Name           string
+		Object         *js.Object
+		ExpectedStatus int
+		Expected       string
+	}
+	tests := []npeTest{
+		{
+			Name:     "Null",
+			Object:   nil,
+			Expected: "",
+		},
+		{
+			Name: "NameAndReasonNoStatus",
+			Object: func() *js.Object {
+				o := js.Global.Get("Object").New()
+				o.Set("reason", "error reason")
+				o.Set("name", "error name")
+				return o
+			}(),
+			ExpectedStatus: 500,
+			Expected:       "error name: error reason",
+		},
+		{
+			Name: "ECONNREFUSED",
+			Object: func() *js.Object {
+				o := js.Global.Get("Object").New()
+				o.Set("code", "ECONNREFUSED")
+				o.Set("errno", "ECONNREFUSED")
+				o.Set("syscall", "connect")
+				o.Set("address", "127.0.0.1")
+				o.Set("port", "5984")
+				o.Set("status", "500")
+				return o
+			}(),
+			ExpectedStatus: 500,
+			Expected:       "connect: connection refused",
+		},
+	}
+	for _, test := range tests {
+		func(test npeTest) {
+			t.Run(test.Name, func(t *testing.T) {
+				result := NewPouchError(test.Object)
+				var msg string
+				if result != nil {
+					msg = result.Error()
+				}
+				if msg != test.Expected {
+					t.Errorf("Expected error: %s\n  Actual error: %s", test.Expected, msg)
+				}
+				if result == nil {
+					return
+				}
+				status := result.(statuser).StatusCode()
+				if status != test.ExpectedStatus {
+					t.Errorf("Expected status %d, got %d", test.ExpectedStatus, status)
+				}
+			})
+		}(test)
+	}
+}

--- a/driver/pouchdb/bindings/errors_test.inc.js
+++ b/driver/pouchdb/bindings/errors_test.inc.js
@@ -1,0 +1,26 @@
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+var inherits = _interopDefault(require('inherits'));
+inherits(PouchError, Error);
+
+function PouchError(status, error, reason) {
+  Error.call(this, reason);
+  this.status = status;
+  this.name = error;
+  this.message = reason;
+  this.error = true;
+}
+
+PouchError.prototype.toString = function () {
+  return JSON.stringify({
+    status: this.status,
+    name: this.name,
+    message: this.message,
+    reason: this.reason
+  });
+};
+
+$global.ReconstitutePouchError = function(str) {
+    const o = JSON.parse(str);
+    Object.setPrototypeOf(o, PouchError.prototype);
+    return o;
+};

--- a/driver/pouchdb/replication.go
+++ b/driver/pouchdb/replication.go
@@ -68,10 +68,10 @@ func (r *replication) Update(ctx context.Context, state *driver.ReplicationInfo)
 		r.state = kivik.ReplicationStarted
 	}
 	if info != nil {
-		if r.startTime.IsZero() && !info.StartTime.IsZero() {
+		if r.startTime.IsZero() && info.Get("start_time") != js.Undefined && !info.StartTime.IsZero() {
 			r.startTime = info.StartTime
 		}
-		if r.endTime.IsZero() && !info.EndTime.IsZero() {
+		if r.endTime.IsZero() && info.Get("end_time") != js.Undefined && !info.EndTime.IsZero() {
 			r.endTime = info.EndTime
 		}
 	}

--- a/driver/pouchdb/replication.go
+++ b/driver/pouchdb/replication.go
@@ -55,7 +55,8 @@ func (r *replication) EndTime() time.Time    { defer r.readLock()(); return r.en
 func (r *replication) State() string         { defer r.readLock()(); return string(r.state) }
 func (r *replication) Err() error            { defer r.readLock()(); return r.err }
 
-func (r *replication) Update(ctx context.Context, state *driver.ReplicationInfo) error {
+func (r *replication) Update(ctx context.Context, state *driver.ReplicationInfo) (err error) {
+	defer bindings.RecoverError(&err)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	event, info, err := r.rh.Status()

--- a/driver/pouchdb/replication.go
+++ b/driver/pouchdb/replication.go
@@ -60,9 +60,13 @@ func (r *replication) Update(ctx context.Context, state *driver.ReplicationInfo)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	event, info, err := r.rh.Status()
+	if err != nil {
+		return err
+	}
 	switch event {
 	case bindings.ReplicationEventDenied, bindings.ReplicationEventError:
 		r.state = kivik.ReplicationError
+		r.err = bindings.NewPouchError(info.Object)
 	case bindings.ReplicationEventComplete:
 		r.state = kivik.ReplicationComplete
 	case bindings.ReplicationEventPaused, bindings.ReplicationEventChange, bindings.ReplicationEventActive:
@@ -76,7 +80,6 @@ func (r *replication) Update(ctx context.Context, state *driver.ReplicationInfo)
 			r.endTime = info.EndTime
 		}
 	}
-	r.err = err
 	return nil
 }
 

--- a/driver/pouchdb/replicationEvents.go
+++ b/driver/pouchdb/replicationEvents.go
@@ -17,7 +17,6 @@ type replicationState struct {
 	DocsRead         int64     `js:"docs_read"`
 	DocsWritten      int64     `js:"docs_written"`
 	DocWriteFailures int64     `js:"doc_write_failures"`
-	Status           string    `js:"status"`
 	LastSeq          string    `js:"last_seq"`
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "pouchdb-find": "*",
         "pouchdb-all-dbs": "*",
         "memdown": ">=1.1.0",
+        "inherits": "*",
         "xhr2": "*"
     }
 }

--- a/test/client/replicate.go
+++ b/test/client/replicate.go
@@ -78,11 +78,11 @@ func testReplication(ctx *kt.Context, client *kivik.Client) {
 		})
 		ctx.Run("MissingSource", func(ctx *kt.Context) {
 			ctx.Parallel()
-			doReplicationTest(ctx, client, dbtarget, "http://localhost:5984/foo")
+			doReplicationTest(ctx, client, dbtarget, ctx.MustString("NotFoundDB"))
 		})
 		ctx.Run("MissingTarget", func(ctx *kt.Context) {
 			ctx.Parallel()
-			doReplicationTest(ctx, client, "http://localhost:5984/foo", dbsource)
+			doReplicationTest(ctx, client, ctx.MustString("NotFoundDB"), dbsource)
 		})
 		ctx.Run("Cancel", func(ctx *kt.Context) {
 			ctx.Parallel()

--- a/test/cloudant.go
+++ b/test/cloudant.go
@@ -201,6 +201,7 @@ func init() {
 
 		"GetReplications/NoAuth.status": kivik.StatusUnauthorized,
 
+		"Replicate.NotFoundDB":                                  "http://localhost:5984/foo",
 		"Replicate.timeoutSeconds":                              300,
 		"Replicate/RW/NoAuth.status":                            kivik.StatusUnauthorized,
 		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusInternalServerError,

--- a/test/couchdb16.go
+++ b/test/couchdb16.go
@@ -147,6 +147,7 @@ func init() {
 
 		"GetReplications/NoAuth.status": kivik.StatusForbidden,
 
+		"Replicate.NotFoundDB":                                  "http://localhost:5984/foo",
 		"Replicate.timeoutSeconds":                              120,
 		"Replicate.prefix":                                      "none",
 		"Replicate/RW/NoAuth.status":                            kivik.StatusForbidden,

--- a/test/couchdb20.go
+++ b/test/couchdb20.go
@@ -170,7 +170,8 @@ func init() {
 
 		"GetReplications/NoAuth.status": kivik.StatusUnauthorized,
 
-		"Replicate.timeoutSeconds":                              15,
+		"Replicate.NotFoundDB":                                  "http://localhost:5984/foo",
+		"Replicate.timeoutSeconds":                              60,
 		"Replicate.prefix":                                      "http://localhost:5984/",
 		"Replicate/RW/NoAuth.status":                            kivik.StatusForbidden,
 		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusInternalServerError,

--- a/test/pouchdb.go
+++ b/test/pouchdb.go
@@ -77,11 +77,7 @@ func init() {
 		"DeleteIndex/RW/Admin/group/NotFoundDdoc.status": kivik.StatusNotFound,
 		"DeleteIndex/RW/Admin/group/NotFoundName.status": kivik.StatusNotFound,
 
-		"Replicate.prefix":                                      "none",
-		"Replicate.timeoutSeconds":                              5,
-		"Replicate.mode":                                        "pouchdb",
-		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusUnauthorized,
-		"Replicate/RW/Admin/group/MissingTarget/Results.status": kivik.StatusUnauthorized,
+		"Replicate.skip": true, // No need to do this for both Local and Remote
 
 		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,
 	})

--- a/test/pouchdb.go
+++ b/test/pouchdb.go
@@ -3,6 +3,10 @@
 package test
 
 import (
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/flimzy/kivik"
 	"github.com/flimzy/kivik/test/kt"
 	"github.com/gopherjs/gopherjs/js"
@@ -180,6 +184,19 @@ func init() {
 		"Put/RW/NoAuth/group/LeadingUnderscoreInID.status": kivik.StatusBadRequest,
 		"Put/RW/NoAuth/group/Conflict.status":              kivik.StatusConflict,
 
+		"Replicate.NotFoundDB": func() string {
+			var dsn string
+			for _, env := range []string{"KIVIK_TEST_DSN_COUCH16", "KIVIK_TEST_DSN_COUCH20", "KIVIK_TEST_DSN_CLOUDANT"} {
+				dsn = os.Getenv(env)
+				if dsn != "" {
+					break
+				}
+			}
+			parsed, _ := url.Parse(dsn)
+			parsed.User = nil
+			return strings.TrimSuffix(parsed.String(), "/") + "/doesntexist"
+
+		}(),
 		"Replicate.prefix":                                       "none",
 		"Replicate.timeoutSeconds":                               5,
 		"Replicate.mode":                                         "pouchdb",

--- a/test/pouchdb.go
+++ b/test/pouchdb.go
@@ -73,9 +73,11 @@ func init() {
 		"DeleteIndex/RW/Admin/group/NotFoundDdoc.status": kivik.StatusNotFound,
 		"DeleteIndex/RW/Admin/group/NotFoundName.status": kivik.StatusNotFound,
 
-		"Replicate.prefix":         "none",
-		"Replicate.timeoutSeconds": 5,
-		"Replicate.mode":           "pouchdb",
+		"Replicate.prefix":                                      "none",
+		"Replicate.timeoutSeconds":                              5,
+		"Replicate.mode":                                        "pouchdb",
+		"Replicate/RW/Admin/group/MissingSource/Results.status": kivik.StatusUnauthorized,
+		"Replicate/RW/Admin/group/MissingTarget/Results.status": kivik.StatusUnauthorized,
 
 		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,
 	})
@@ -178,9 +180,13 @@ func init() {
 		"Put/RW/NoAuth/group/LeadingUnderscoreInID.status": kivik.StatusBadRequest,
 		"Put/RW/NoAuth/group/Conflict.status":              kivik.StatusConflict,
 
-		"Replicate.prefix":         "none",
-		"Replicate.timeoutSeconds": 5,
-		"Replicate.mode":           "pouchdb",
+		"Replicate.prefix":                                       "none",
+		"Replicate.timeoutSeconds":                               5,
+		"Replicate.mode":                                         "pouchdb",
+		"Replicate/RW/Admin/group/MissingSource/Results.status":  kivik.StatusUnauthorized,
+		"Replicate/RW/Admin/group/MissingTarget/Results.status":  kivik.StatusUnauthorized,
+		"Replicate/RW/NoAuth/group/MissingSource/Results.status": kivik.StatusUnauthorized,
+		"Replicate/RW/NoAuth/group/MissingTarget/Results.status": kivik.StatusUnauthorized,
 
 		"Query/RW/group/Admin/WithoutDocs/ScanDoc.status":  kivik.StatusBadRequest,
 		"Query/RW/group/NoAuth/WithoutDocs/ScanDoc.status": kivik.StatusBadRequest,

--- a/test/pouchdb.go
+++ b/test/pouchdb.go
@@ -114,8 +114,8 @@ func init() {
 		"AllDocs/Admin/_replicator.offset":                   0,
 		"AllDocs/Admin/_users.expected":                      []string{"_design/_auth"},
 		"AllDocs/Admin/chicken.status":                       kivik.StatusNotFound,
-		"AllDocs/NoAuth/_replicator.status":                  kivik.StatusForbidden,
-		"AllDocs/NoAuth/_users.status":                       kivik.StatusForbidden,
+		"AllDocs/NoAuth/_replicator.status":                  kivik.StatusUnauthorized,
+		"AllDocs/NoAuth/_users.status":                       kivik.StatusUnauthorized,
 		"AllDocs/NoAuth/chicken.status":                      kivik.StatusNotFound,
 		"AllDocs/Admin/_replicator/WithDocs/UpdateSeq.skip":  true,
 		"AllDocs/Admin/_users/WithDocs/UpdateSeq.skip":       true,
@@ -163,15 +163,15 @@ func init() {
 		"GetAttachmentMeta/RW/group/Admin/foo/NotFound.status":  kivik.StatusNotFound,
 		"GetAttachmentMeta/RW/group/NoAuth/foo/NotFound.status": kivik.StatusNotFound,
 
-		"PutAttachment/RW/group/Admin/Conflict.status":         kivik.StatusConflict,
-		"PutAttachment/RW/group/NoAuth/Conflict.status":        kivik.StatusConflict,
+		"PutAttachment/RW/group/Admin/Conflict.status":         kivik.StatusInternalServerError, // Couch 2.0 bug
+		"PutAttachment/RW/group/NoAuth/Conflict.status":        kivik.StatusInternalServerError, // Couch 2.0 bug
 		"PutAttachment/RW/group/NoAuth/UpdateDesignDoc.status": kivik.StatusUnauthorized,
 		"PutAttachment/RW/group/NoAuth/CreateDesignDoc.status": kivik.StatusUnauthorized,
 
 		// "DeleteAttachment/RW/group/Admin/NotFound.status":  kivik.StatusNotFound, // COUCHDB-3362
 		// "DeleteAttachment/RW/group/NoAuth/NotFound.status": kivik.StatusNotFound, // COUCHDB-3362
-		"DeleteAttachment/RW/group/Admin/NoDoc.status":      kivik.StatusConflict,
-		"DeleteAttachment/RW/group/NoAuth/NoDoc.status":     kivik.StatusConflict,
+		"DeleteAttachment/RW/group/Admin/NoDoc.status":      kivik.StatusInternalServerError, // Couch 2.0 bug
+		"DeleteAttachment/RW/group/NoAuth/NoDoc.status":     kivik.StatusInternalServerError, // Couch 2.0 bug
 		"DeleteAttachment/RW/group/NoAuth/DesignDoc.status": kivik.StatusUnauthorized,
 
 		"Put/RW/Admin/group/LeadingUnderscoreInID.status":  kivik.StatusBadRequest,


### PR DESCRIPTION
I discovered in the course of working on #134 that some NodeJS system errors were improperly handled by the PouchDB driver. This fixes the known cases.