### PR TITLE
Move system db check into the individual driver.

### DIFF
--- a/driver/memory/memory_test.go
+++ b/driver/memory/memory_test.go
@@ -97,6 +97,15 @@ func TestCreateDB(t *testing.T) {
 			DBName: "foo",
 		},
 		{
+			Name:   "UsersDB",
+			DBName: "_users",
+		},
+		{
+			Name:   "SystemDB",
+			DBName: "_foo",
+			Error:  "invalid database name",
+		},
+		{
 			Name:   "Duplicate",
 			DBName: "foo",
 			Setup: func(c driver.Client) {

--- a/kivik.go
+++ b/kivik.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/flimzy/kivik/driver"
 	"github.com/flimzy/kivik/errors"
@@ -119,17 +118,11 @@ func (c *Client) DBExists(ctx context.Context, dbName string, options ...Options
 	return c.driverClient.DBExists(ctx, dbName, opts)
 }
 
-// Copied verbatim from http://docs.couchdb.org/en/2.0.0/api/database/common.html#head--db
-var validDBName = regexp.MustCompile("^[a-z][a-z0-9_$()+/-]*$")
-
 // CreateDB creates a DB of the requested name.
 func (c *Client) CreateDB(ctx context.Context, dbName string, options ...Options) error {
 	opts, err := mergeOptions(options...)
 	if err != nil {
 		return err
-	}
-	if !validDBName.MatchString(dbName) {
-		return errors.Status(StatusBadRequest, "invalid database name")
 	}
 	return c.driverClient.CreateDB(ctx, dbName, opts)
 }


### PR DESCRIPTION
The list of allowed system databases is backend-specific (e.g. CouchDB 2.0 allows `_global_changes`, while 1.6 does not), so this check belongs in the backend or per-driver, rather than in the main Kivik library.