### PR TITLE
Wrap xhr2 loading in try/catch block to work around GopherJS limitation

### DIFF
--- a/authdb/authgroup/authgroup_js_test.go
+++ b/authdb/authgroup/authgroup_js_test.go
@@ -1,0 +1,14 @@
+// +build js
+
+package authgroup
+
+import (
+	"net/http"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func init() {
+	js.Global.Set("XMLHttpRequest", js.Global.Call("require", "xhr2"))
+	http.DefaultTransport = &http.XHRTransport{}
+}

--- a/authdb/authgroup/authgroup_test.inc.js
+++ b/authdb/authgroup/authgroup_test.inc.js
@@ -1,1 +1,0 @@
-global.XMLHttpRequest = require('xhr2');

--- a/driver/couchdb/chttp/chttp_js_test.go
+++ b/driver/couchdb/chttp/chttp_js_test.go
@@ -1,0 +1,14 @@
+// +build js
+
+package chttp
+
+import (
+	"net/http"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func init() {
+	js.Global.Set("XMLHttpRequest", js.Global.Call("require", "xhr2"))
+	http.DefaultTransport = &http.XHRTransport{}
+}

--- a/driver/couchdb/chttp/chttp_test.inc.js
+++ b/driver/couchdb/chttp/chttp_test.inc.js
@@ -1,1 +1,0 @@
-global.XMLHttpRequest = require('xhr2');

--- a/driver/couchdb/main_js_test.go
+++ b/driver/couchdb/main_js_test.go
@@ -1,0 +1,14 @@
+// +build js
+
+package couchdb
+
+import (
+	"net/http"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func init() {
+	js.Global.Set("XMLHttpRequest", js.Global.Call("require", "xhr2"))
+	http.DefaultTransport = &http.XHRTransport{}
+}

--- a/driver/couchdb/main_test.inc.js
+++ b/driver/couchdb/main_test.inc.js
@@ -1,1 +1,0 @@
-global.XMLHttpRequest = require('xhr2');


### PR DESCRIPTION
GopherJS improperly includes `*_test.inc.js` files when building non tests.  See https://github.com/gopherjs/gopherjs/issues/655

This works around the bug so that failure loading the `xhr2` module doesn't cause a crash in the browser.