### PR TITLE
Fix memdown usage during tests

### DIFF
--- a/driver/pouchdb/bindings/nofind_test.go
+++ b/driver/pouchdb/bindings/nofind_test.go
@@ -9,19 +9,25 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
+func init() {
+	memPouch := js.Global.Get("PouchDB").Call("defaults", map[string]interface{}{
+		"db": js.Global.Call("require", "memdown"),
+	})
+	js.Global.Set("PouchDB", memPouch)
+}
+
 // TestNoFind tests that Find() properly returns NotImplemented when the
 // pouchdb-find plugin is not loaded.
 func TestNoFindPlugin(t *testing.T) {
-	memdown := js.Global.Call("require", "memdown")
 	t.Run("FindLoaded", func(t *testing.T) {
-		db := GlobalPouchDB().New("foo", map[string]interface{}{"db": memdown})
+		db := GlobalPouchDB().New("foo", nil)
 		_, err := db.Find(context.Background(), "")
 		if errors.StatusCode(err) == kivik.StatusNotImplemented {
 			t.Errorf("Got StatusNotImplemented when pouchdb-find should be loaded")
 		}
 	})
 	t.Run("FindNotLoaded", func(t *testing.T) {
-		db := GlobalPouchDB().New("foo", map[string]interface{}{"db": memdown})
+		db := GlobalPouchDB().New("foo", nil)
 		db.Object.Set("find", nil) // Fake it
 		_, err := db.Find(context.Background(), "")
 		if code := errors.StatusCode(err); code != kivik.StatusNotImplemented {

--- a/driver/pouchdb/db_test.go
+++ b/driver/pouchdb/db_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 func init() {
-	js.Global.Get("PouchDB").Call("defaults", map[string]interface{}{
+	memPouch := js.Global.Get("PouchDB").Call("defaults", map[string]interface{}{
 		"db": js.Global.Call("require", "memdown"),
 	})
+	js.Global.Set("PouchDB", memPouch)
 }
 
 func TestPut(t *testing.T) {

--- a/test/pouchdb_test.go
+++ b/test/pouchdb_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/flimzy/kivik"
 	_ "github.com/flimzy/kivik/driver/pouchdb"
-	"github.com/flimzy/kivik/driver/pouchdb/bindings"
 	"github.com/flimzy/kivik/test/kt"
 )
 
 func init() {
-	bindings.GlobalPouchDB().Call("defaults", map[string]interface{}{
+	memPouch := js.Global.Get("PouchDB").Call("defaults", map[string]interface{}{
 		"db": js.Global.Call("require", "memdown"),
 	})
+	js.Global.Set("PouchDB", memPouch)
 }
 
 func TestPouchLocal(t *testing.T) {


### PR DESCRIPTION
defaults() returns a new constructor, rather than modifying the existing
one.  This fixes the previous faulty assumption.