### PR TITLE
Remove _attachments key when storing docs in memory driver

### DIFF
--- a/driver/memory/db.go
+++ b/driver/memory/db.go
@@ -84,6 +84,8 @@ func (d *db) Put(_ context.Context, docID string, doc interface{}) (rev string, 
 		return "", err
 	}
 	couchDoc["_id"] = docID
+	// TODO: Add support for storing attachments.
+	delete(couchDoc, "_attachments")
 
 	if last, ok := d.db.latestRevision(docID); ok {
 		if !last.Deleted && !isLocal && couchDoc.Rev() != fmt.Sprintf("%d-%s", last.ID, last.Rev) {

--- a/driver/memory/db_test.go
+++ b/driver/memory/db_test.go
@@ -191,6 +191,25 @@ func TestPut(t *testing.T) {
 				return db
 			},
 		},
+		{
+			Name:  "WithAttachments",
+			DocID: "duck",
+			Doc: map[string]interface{}{
+				"_id":   "duck",
+				"value": "quack",
+				"_attachments": []map[string]interface{}{
+					{"foo.css": map[string]string{
+						"content_type": "text/css",
+						"data":         "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8=",
+					}},
+				},
+			},
+			Expected: map[string]string{
+				"_id":   "duck",
+				"_rev":  "1-xxx",
+				"value": "quack",
+			},
+		},
 	}
 	for _, test := range tests {
 		func(test putTest) {


### PR DESCRIPTION
Long-term, attachments need to be stored properly, but as attachments, not
in the document directly.