### PR TITLE
Add basic library with raw collation support.

### DIFF
--- a/collate/collate.go
+++ b/collate/collate.go
@@ -1,0 +1,71 @@
+package collate
+
+import (
+	"math"
+	"reflect"
+)
+
+// Collation provides an interface around a CouchDB collation definition.
+type Collation interface {
+	Eq(i, j interface{}) bool
+	LT(i, j interface{}) bool
+	LTE(i, j interface{}) bool
+	GT(i, j interface{}) bool
+	GTE(i, j interface{}) bool
+}
+
+type comparison int
+
+const (
+	lt comparison = iota - 1
+	eq
+	gt
+)
+
+func (c comparison) String() string {
+	switch {
+	case c > 0:
+		return "greater than"
+	case c < 0:
+		return "less than"
+	default:
+		return "equal"
+	}
+}
+
+type couchType int
+
+const (
+	couchNull couchType = iota
+	couchBool
+	couchNumber
+	couchString
+	couchArray
+	couchObject
+)
+
+func couchTypeOf(i interface{}) couchType {
+	if i == nil {
+		return couchNull
+	}
+	switch t := i.(type) {
+	case bool:
+		return couchBool
+	case float64:
+		if math.IsInf(t, 0) || math.IsNaN(t) {
+			return couchNull
+		}
+		return couchNumber
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32:
+		return couchNumber
+	case string:
+		return couchString
+	case map[string]interface{}:
+		return couchObject
+	}
+	switch reflect.ValueOf(i).Kind() {
+	case reflect.Slice, reflect.Array:
+		return couchArray
+	}
+	panic("unknown type")
+}

--- a/collate/collate_test.go
+++ b/collate/collate_test.go
@@ -1,0 +1,138 @@
+package collate
+
+import (
+	"math"
+	"testing"
+)
+
+func TestComparisonString(t *testing.T) {
+	type csTest struct {
+		name     string
+		c        comparison
+		expected string
+	}
+	tests := []csTest{
+		{
+			name:     "less than",
+			c:        lt,
+			expected: "less than",
+		},
+		{
+			name:     "greater than",
+			c:        gt,
+			expected: "greater than",
+		},
+		{
+			name:     "equal",
+			c:        eq,
+			expected: "equal",
+		},
+		{
+			name:     "-100",
+			c:        -100,
+			expected: "less than",
+		},
+		{
+			name:     "100",
+			c:        100,
+			expected: "greater than",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.c.String()
+			if result != test.expected {
+				t.Errorf("Unexpected result: %s", result)
+			}
+		})
+	}
+}
+
+func TestCouchTypeOf(t *testing.T) {
+	type ctoTest struct {
+		name     string
+		input    interface{}
+		expected couchType
+		recovery string
+	}
+	tests := []ctoTest{
+		{
+			name:     "nil",
+			expected: couchNull,
+		},
+		{
+			name:     "int",
+			input:    int(3),
+			expected: couchNumber,
+		},
+		{
+			name:     "+inifinity",
+			input:    math.Inf(1),
+			expected: couchNull,
+		},
+		{
+			name:     "-infinity",
+			input:    math.Inf(-1),
+			expected: couchNull,
+		},
+		{
+			name:     "NaN",
+			input:    math.NaN(),
+			expected: couchNull,
+		},
+		{
+			name:     "float64",
+			input:    float64(3.3),
+			expected: couchNumber,
+		},
+		{
+			name:     "string",
+			input:    "foo",
+			expected: couchString,
+		},
+		{
+			name:     "slice",
+			input:    []int{1, 2, 3},
+			expected: couchArray,
+		},
+		{
+			name:     "array",
+			input:    [3]int{1, 2, 3},
+			expected: couchArray,
+		},
+		{
+			name:     "map",
+			input:    map[string]interface{}{"foo": "bar"},
+			expected: couchObject,
+		},
+		{
+			name:     "struct",
+			input:    struct{ Foo string }{"foo"},
+			recovery: "unknown type",
+		},
+		{
+			name:     "bool",
+			input:    true,
+			expected: couchBool,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := func() (recovery string) {
+				defer func() {
+					if r := recover(); r != nil {
+						recovery = r.(string)
+					}
+				}()
+				result := couchTypeOf(test.input)
+				if result != test.expected {
+					t.Errorf("Unexpected type: %d", result)
+				}
+				return
+			}()
+			if r != test.recovery {
+				t.Errorf("Unexpected recovery: %s", r)
+			}
+		})
+	}
+}

--- a/collate/raw.go
+++ b/collate/raw.go
@@ -1,0 +1,178 @@
+package collate
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+)
+
+// Raw provides raw (byte-wise) collation of strings.
+type Raw struct{}
+
+var _ Collation = &Raw{}
+
+func (r *Raw) cmp(i, j interface{}) comparison {
+	iType, jType := couchTypeOf(i), couchTypeOf(j)
+	if iType < jType {
+		return lt
+	}
+	if iType > jType {
+		return gt
+	}
+	switch iType {
+	case couchBool, couchNumber, couchString:
+		if i == j {
+			return eq
+		}
+	}
+	switch iType {
+	case couchNull:
+		return eq
+	case couchBool:
+		if i.(bool) {
+			return gt
+		}
+		return lt
+	case couchNumber:
+		return numberCmp(i, j)
+	case couchString:
+		return r.stringCmp(i.(string), j.(string))
+	case couchArray:
+		return r.arrayCmp(i, j)
+	case couchObject:
+		return r.objectCmp(i, j)
+	}
+	panic(fmt.Sprintf("unknown couch type: %v", iType))
+}
+
+func (r *Raw) stringCmp(i, j string) comparison {
+	if i < j {
+		return lt
+	}
+	if i > j {
+		return gt
+	}
+	return eq
+}
+
+func (r *Raw) arrayCmp(i, j interface{}) comparison {
+	iv, jv := reflect.ValueOf(i), reflect.ValueOf(j)
+	maxLen := iv.Len()
+	if jv.Len() < maxLen {
+		maxLen = jv.Len()
+	}
+	for k := 0; k < maxLen; k++ {
+		if cmp := r.cmp(iv.Index(k).Interface(), jv.Index(k).Interface()); cmp != eq {
+			return cmp
+		}
+	}
+	if iv.Len() == jv.Len() {
+		return eq
+	}
+	if iv.Len() < jv.Len() {
+		return lt
+	}
+	return gt
+}
+
+func (r *Raw) objectCmp(i, j interface{}) comparison {
+	iv := i.(map[string]interface{})
+	jv := j.(map[string]interface{})
+	ikeys := make([]string, 0, len(iv))
+	jkeys := make([]string, 0, len(jv))
+	for k := range iv {
+		ikeys = append(ikeys, k)
+	}
+	for k := range jv {
+		jkeys = append(jkeys, k)
+	}
+	sort.Strings(ikeys)
+	sort.Strings(jkeys)
+	maxLen := len(ikeys)
+	if maxLen > len(jkeys) {
+		maxLen = len(jkeys)
+	}
+	for k := 0; k < maxLen; k++ {
+		if cmp := r.stringCmp(ikeys[k], jkeys[k]); cmp != eq {
+			return cmp
+		}
+		key := ikeys[k]
+		if cmp := r.cmp(iv[key], jv[key]); cmp != eq {
+			return cmp
+		}
+	}
+	if len(ikeys) < len(jkeys) {
+		return lt
+	}
+	if len(ikeys) > len(jkeys) {
+		return gt
+	}
+	return eq
+}
+
+func numberCmp(i, j interface{}) comparison {
+	fi, fj := toFloat(i), toFloat(j)
+	if fi < fj {
+		return lt
+	}
+	if fi > fj {
+		return gt
+	}
+	return eq
+}
+
+func toFloat(i interface{}) float64 {
+	switch t := i.(type) {
+	case int:
+		return float64(t)
+	case int8:
+		return float64(t)
+	case int16:
+		return float64(t)
+	case int32:
+		return float64(t)
+	case int64:
+		return float64(t)
+	case uint:
+		return float64(t)
+	case uint8:
+		return float64(t)
+	case uint16:
+		return float64(t)
+	case uint32:
+		return float64(t)
+	case uint64:
+		return float64(t)
+	case float32:
+		return float64(t)
+	case float64:
+		return t
+	}
+	return math.NaN()
+}
+
+// Eq returns true if i and j are equal.
+func (r *Raw) Eq(i, j interface{}) bool {
+	return r.cmp(i, j) == eq
+}
+
+// LT returns true if i is less than j.
+func (r *Raw) LT(i, j interface{}) bool {
+	return r.cmp(i, j) == lt
+}
+
+// LTE returns true if i is less than or equal to j.
+func (r *Raw) LTE(i, j interface{}) bool {
+	return r.cmp(i, j) <= eq
+}
+
+// GT returns true if i is greater than j.
+func (r *Raw) GT(i, j interface{}) bool {
+	return r.cmp(i, j) == gt
+}
+
+// GTE returns true if i is greater than or equal to j.
+func (r *Raw) GTE(i, j interface{}) bool {
+	return r.cmp(i, j) >= eq
+}

--- a/collate/raw_test.go
+++ b/collate/raw_test.go
@@ -1,0 +1,350 @@
+package collate
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestRawCmp(t *testing.T) {
+	c := &Raw{}
+	type cmpTest struct {
+		name     string
+		i, j     interface{}
+		expected comparison
+	}
+	tests := []cmpTest{
+		{
+			name:     "both nil",
+			expected: eq,
+		},
+		{
+			name:     "nil vs number",
+			j:        123,
+			expected: lt,
+		},
+		{
+			name:     "number vs nil",
+			i:        123,
+			expected: gt,
+		},
+		{
+			name:     "Nan vs nil",
+			i:        math.NaN(),
+			expected: eq,
+		},
+		{
+			name: "true vs false",
+			i:    true, j: false,
+			expected: gt,
+		},
+		{
+			name: "false vs true",
+			i:    false, j: true,
+			expected: lt,
+		},
+		{
+			name: "true vs true",
+			i:    true, j: true,
+			expected: eq,
+		},
+		{
+			name: "1 vs 2",
+			i:    1, j: 2,
+			expected: lt,
+		},
+		{
+			name: "123 vs 123.005",
+			i:    int(123), j: float32(123.005),
+			expected: lt,
+		},
+		{
+			name: "a vs b",
+			i:    "a", j: "b",
+			expected: lt,
+		},
+		{
+			name: "aaaa vs a",
+			i:    "aaaa", j: "a",
+			expected: gt,
+		},
+		{
+			name: "array vs number",
+			i:    []int{1, 2, 3}, j: 123,
+			expected: gt,
+		},
+		{
+			name: "2 arrays",
+			i:    []int{1, 2, 3}, j: []int{2, 3},
+			expected: lt,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := c.cmp(test.i, test.j)
+			if result != test.expected {
+				t.Errorf("Unexpected result: %s", result)
+			}
+		})
+	}
+}
+
+func TestRawEqualityOperators(t *testing.T) {
+	c := &Raw{}
+	type eqTest struct {
+		name string
+		i, j interface{}
+		lt   bool
+		lte  bool
+		eq   bool
+		gt   bool
+		gte  bool
+	}
+	tests := []eqTest{
+		{
+			name: "nil/nil",
+			lte:  true, eq: true, gte: true,
+		},
+		{
+			name: "nil/number",
+			j:    123,
+			lt:   true, lte: true,
+		},
+		{
+			name: "number/nil",
+			i:    123,
+			gt:   true, gte: true,
+		},
+		{
+			name: "int vs float",
+			i:    int(123),
+			j:    float32(400),
+			lt:   true, lte: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if x := c.LT(test.i, test.j); x != test.lt {
+				t.Errorf("LT returned %t", x)
+			}
+			if x := c.LTE(test.i, test.j); x != test.lte {
+				t.Errorf("LTE returned %t", x)
+			}
+			if x := c.Eq(test.i, test.j); x != test.eq {
+				t.Errorf("Eq returned %t", x)
+			}
+			if x := c.GT(test.i, test.j); x != test.gt {
+				t.Errorf("GT returned %t", x)
+			}
+			if x := c.GTE(test.i, test.j); x != test.gte {
+				t.Errorf("GTE returned %t", x)
+			}
+		})
+	}
+}
+
+func TestNumberCmp(t *testing.T) {
+	type ncTest struct {
+		name     string
+		i, j     interface{}
+		expected comparison
+	}
+	tests := []ncTest{
+		{
+			name: "int(1) vs int(2)",
+			i:    1, j: 2,
+			expected: lt,
+		},
+		{
+			name: "float32(1.12) vs int64(3)",
+			i:    float32(1.12), j: int64(3),
+			expected: lt,
+		},
+		{
+			name: "int8(12) vs int16(2)",
+			i:    int8(12), j: int16(2),
+			expected: gt,
+		},
+		{
+			name: "int32(1) vs float64(0.0000000001)",
+			i:    int32(1), j: float64(0.0000000001),
+			expected: gt,
+		},
+		{
+			name: "uint(8) vs int(-98)",
+			i:    uint(8), j: int(-98),
+			expected: gt,
+		},
+		{
+			name: "uint(1) vs uint16(1)",
+			i:    uint(1), j: uint16(1),
+			expected: eq,
+		},
+		{
+			name: "uint8(1) vs uint32(7)",
+			i:    uint8(1), j: uint32(7),
+			expected: lt,
+		},
+		{
+			name: "uint64(3) vs int(-10)",
+			i:    uint64(3), j: int(-10),
+			expected: gt,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := numberCmp(test.i, test.j)
+			if result != test.expected {
+				t.Errorf("Unexpected result: %s", result)
+			}
+		})
+	}
+}
+
+func TestToFloat(t *testing.T) {
+	type tfTest struct {
+		i        interface{}
+		expected float64
+	}
+	tests := []tfTest{
+		{i: int(1234), expected: 1234},
+		{i: int8(-60), expected: -60},
+		{i: int16(-9), expected: -9},
+		{i: int32(32), expected: 32},
+		{i: int64(64), expected: 64},
+		{i: uint(1234), expected: 1234},
+		{i: uint8(100), expected: 100},
+		{i: uint16(99), expected: 99},
+		{i: uint32(32), expected: 32},
+		{i: uint64(64), expected: 64},
+		{i: float32(123), expected: 123},
+		{i: float64(0.00009), expected: 0.00009},
+		{i: "foo", expected: math.NaN()},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T(%v)", test.i, test.i), func(t *testing.T) {
+			result := toFloat(test.i)
+			if result != test.expected && !(math.IsNaN(result) && math.IsNaN(test.expected)) {
+				t.Errorf("Unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestRawArrayCmp(t *testing.T) {
+	c := &Raw{}
+	type acTest struct {
+		name     string
+		i, j     interface{}
+		expected comparison
+	}
+	tests := []acTest{
+		{
+			name: "empty slices",
+			i:    []int{}, j: []int{},
+			expected: eq,
+		},
+		{
+			name: "1 item vs empty",
+			i:    []int{1}, j: []int{},
+			expected: gt,
+		},
+		{
+			name: "empty vs 3 items",
+			i:    []int{}, j: []int{1, 2, 3},
+			expected: lt,
+		},
+		{
+			name: "[1,2] vs [2,3]",
+			i:    []int{1, 2}, j: []int{2, 3},
+			expected: lt,
+		},
+		{
+			name: "longer vs shorter",
+			i:    []int{1, 2, 3}, j: []int{1, 2},
+			expected: gt,
+		},
+		{
+			name: "numbers vs strings",
+			i:    []int{1, 2, 3}, j: []string{"foo", "bar"},
+			expected: lt,
+		},
+		{
+			name: "intermingled",
+			i:    []interface{}{1, "foo"}, j: []interface{}{"foo", 1},
+			expected: lt,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := c.arrayCmp(test.i, test.j)
+			if result != test.expected {
+				t.Errorf("Unexpected result: %s", result)
+			}
+		})
+	}
+}
+
+func TestRawObjectCmp(t *testing.T) {
+	c := &Raw{}
+	type ocTest struct {
+		name     string
+		i, j     interface{}
+		expected comparison
+	}
+	tests := []ocTest{
+		{
+			name: "empty objects",
+			i:    map[string]interface{}{}, j: map[string]interface{}{},
+			expected: eq,
+		},
+		{
+			name: "different keys",
+			i:    map[string]interface{}{"a": 1}, j: map[string]interface{}{"b": 1},
+			expected: lt,
+		},
+		{
+			name: "different values",
+			i:    map[string]interface{}{"a": 2}, j: map[string]interface{}{"a": 1},
+			expected: gt,
+		},
+		{
+			name: "equal values",
+			i:    map[string]interface{}{"a": 1}, j: map[string]interface{}{"a": 1},
+			expected: eq,
+		},
+		{
+			name: "longer vs shorter",
+			i:    map[string]interface{}{"a": 1, "b": 100}, j: map[string]interface{}{"a": 1},
+			expected: gt,
+		},
+		{
+			name: "shorter vs",
+			i:    map[string]interface{}{"a": 1}, j: map[string]interface{}{"a": 1, "b": 100},
+			expected: lt,
+		},
+		{
+			name: "string vs number",
+			i:    map[string]interface{}{"a": "foo"}, j: map[string]interface{}{"a": 1},
+			expected: gt,
+		},
+		{
+			name: "nested",
+			i: map[string]interface{}{
+				"a": map[string]interface{}{"b": 1},
+			},
+			j: map[string]interface{}{
+				"a": map[string]interface{}{"b": 2},
+			},
+			expected: lt,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := c.objectCmp(test.i, test.j)
+			if result != test.expected {
+				t.Errorf("Unexpected result: %s", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This library isn't being used yet, but will be used by the #166.  Long-term, this should be expanded to support CouchDB's ICU collation method, but it's a bit magical, and [it looks like PouchDB](https://github.com/pouchdb/pouchdb/issues/40) decided not to even try to mimic that behavior, so maybe it can be considered low-priority.