### PR TITLE
Fix "Uncaught ReferenceError: require is not defined" when using pouchhdb driver in a browser

### DIFF
--- a/driver/pouchdb/bindings/errors_test.inc.js
+++ b/driver/pouchdb/bindings/errors_test.inc.js
@@ -1,26 +1,28 @@
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
-var inherits = _interopDefault(require('inherits'));
-inherits(PouchError, Error);
+if (typeof window === 'undefined') {
+  function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+  var inherits = _interopDefault(require('inherits'));
+  inherits(PouchError, Error);
 
-function PouchError(status, error, reason) {
-  Error.call(this, reason);
-  this.status = status;
-  this.name = error;
-  this.message = reason;
-  this.error = true;
+  function PouchError(status, error, reason) {
+    Error.call(this, reason);
+    this.status = status;
+    this.name = error;
+    this.message = reason;
+    this.error = true;
+  }
+
+  PouchError.prototype.toString = function () {
+    return JSON.stringify({
+      status: this.status,
+      name: this.name,
+      message: this.message,
+      reason: this.reason
+    });
+  };
+
+  $global.ReconstitutePouchError = function(str) {
+      const o = JSON.parse(str);
+      Object.setPrototypeOf(o, PouchError.prototype);
+      return o;
+  };
 }
-
-PouchError.prototype.toString = function () {
-  return JSON.stringify({
-    status: this.status,
-    name: this.name,
-    message: this.message,
-    reason: this.reason
-  });
-};
-
-$global.ReconstitutePouchError = function(str) {
-    const o = JSON.parse(str);
-    Object.setPrototypeOf(o, PouchError.prototype);
-    return o;
-};


### PR DESCRIPTION
When trying to run a simple example in a browser, I got an `Uncaught ReferenceError: require is not defined` error. The line of code responsible was this one in `errors_test.inc.js`:
```
var inherits = _interopDefault(require('inherits'));
```
Apparently GopherJs loads that file despite the _test suffix. (Perhaps that's a bug?) In any case, my workaround was to not run the code in that file in a browser. There's probably a better solution, but I'm not a JS guru--that's why I'm using GopherJS! 

Thanks!