### PR TITLE
Allow passing options to the BulkDocs() method

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -100,6 +100,13 @@ func (db *DB) BulkDocs(ctx context.Context, docs interface{}, options ...Options
 		}
 		return nil, err
 	}
+	if oldBulkDocer, ok := db.driverDB.(driver.OldBulkDocer); ok {
+		bulki, err := oldBulkDocer.BulkDocs(ctx, docsi)
+		if err != nil {
+			return nil, err
+		}
+		return newBulkResults(ctx, bulki), nil
+	}
 	if bulkDocer, ok := db.driverDB.(driver.BulkDocer); ok {
 		bulki, err := bulkDocer.BulkDocs(ctx, docsi, opts)
 		if err != nil {

--- a/bulk.go
+++ b/bulk.go
@@ -88,7 +88,11 @@ func (r *BulkResults) UpdateErr() error {
 //
 // As with Put, each individual document may be a JSON-marshable object, or a
 // raw JSON string in a []byte, json.RawMessage, or io.Reader.
-func (db *DB) BulkDocs(ctx context.Context, docs interface{}) (*BulkResults, error) {
+func (db *DB) BulkDocs(ctx context.Context, docs interface{}, options ...Options) (*BulkResults, error) {
+	opts, err := mergeOptions(options...)
+	if err != nil {
+		return nil, err
+	}
 	docsi, err := docsInterfaceSlice(docs)
 	if err != nil {
 		if _, ok := err.(errNotSlice); ok {
@@ -97,7 +101,7 @@ func (db *DB) BulkDocs(ctx context.Context, docs interface{}) (*BulkResults, err
 		return nil, err
 	}
 	if bulkDocer, ok := db.driverDB.(driver.BulkDocer); ok {
-		bulki, err := bulkDocer.BulkDocs(ctx, docsi)
+		bulki, err := bulkDocer.BulkDocs(ctx, docsi, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -148,6 +148,17 @@ func (db *bdDB) BulkDocs(_ context.Context, docs []interface{}, options map[stri
 	return nil, db.err
 }
 
+type legacyDB struct {
+	driver.DB
+	err error
+}
+
+var _ driver.OldBulkDocer = &legacyDB{}
+
+func (db *legacyDB) BulkDocs(_ context.Context, docs []interface{}) (driver.BulkResults, error) {
+	return nil, db.err
+}
+
 type nonbdDB struct {
 	driver.DB
 }
@@ -201,6 +212,20 @@ func TestBulkDocs(t *testing.T) {
 				123,
 			},
 			options: Options{"new_edits": true},
+		},
+		{
+			name:     "legacy bulkDocer",
+			dbDriver: &legacyDB{},
+			docs: []interface{}{
+				map[string]string{"_id": "foo"},
+				123,
+			},
+		},
+		{
+			name:     "legacy failure",
+			dbDriver: &legacyDB{err: errors.New("fail")},
+			docs:     []interface{}{1, 2, 3},
+			err:      "fail",
 		},
 	}
 	for _, test := range tests {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -158,6 +158,13 @@ type DB interface {
 	Query(ctx context.Context, ddoc, view string, options map[string]interface{}) (Rows, error)
 }
 
+// OldBulkDocer is deprecated and will be removed in Kivik 2.0. Use BulkDocer instead.
+type OldBulkDocer interface {
+	// BulkDocs alls bulk create, update and/or delete operations. It returns an
+	// iterator over the results.
+	BulkDocs(ctx context.Context, docs []interface{}) (BulkResults, error)
+}
+
 // BulkDocer is an optional interface which may be implemented by a driver to
 // support bulk insert/update operations. For any driver that does not support
 // the BulkDocer interface, the Put or CreateDoc methods will be called for each

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -165,7 +165,7 @@ type DB interface {
 type BulkDocer interface {
 	// BulkDocs alls bulk create, update and/or delete operations. It returns an
 	// iterator over the results.
-	BulkDocs(ctx context.Context, docs []interface{}) (BulkResults, error)
+	BulkDocs(ctx context.Context, docs []interface{}, options map[string]interface{}) (BulkResults, error)
 }
 
 // The Finder is an optional interface which may be implemented by a database. The

--- a/kivik.go
+++ b/kivik.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/imdario/mergo"
+
 	"github.com/flimzy/kivik/driver"
 	"github.com/flimzy/kivik/errors"
-	"github.com/imdario/mergo"
 )
 
 // Client is a client connection handle to a CouchDB-like server.


### PR DESCRIPTION
This PR adds an optional `options` parameter to the `BulkDocs()` method, to allow setting options such as `new_edits`, the `X-Couch-Full-Commit` header, or `all_or_nothing` (for versions < 2.0).

Fixes #208 .

This PR aims for near 100%-backward compatibility.  Client code should remain 100% backward compatible, as the new argument is optional.  The old function signature was:

    BulkDocs(ctx context.Context, docs []interface{}) (*BulkResults, error)

Whereas the new signature is:

    BulkDocs(ctx context.Context, docs []interface{}, options ...Options) (*BulkResults, error)

The only breaking change is that the definition of `driver.BulkDocer` changed.  The old definition lives on for now, as `OldBulkDocer`, but any reference to the exported `driver.BulkDocer` symbol will likely break. As the only drivers in the wild, to my knowledge, are those distributed as part of Kivik, I expect this will affect exactly nobody.

- [x] Add support to kivik (this PR)
- [x] Add support to the CouchDB driver (https://github.com/go-kivik/couchdb/pull/10)
- [x] Add support to the PouchDB driver (https://github.com/go-kivik/pouchdb/pull/11)
