### PR TITLE
Don't try to cache docker dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
     directories:
         - node_modules
         - $HOME/gopath/pkg
-        - /var/lib/docker
 
 language: go
 


### PR DESCRIPTION
It wasn't working. From the Travis log:

```
adding /home/travis/gopath/src/github.com/flimzy/kivik/node_modules to cache
creating directory /home/travis/gopath/src/github.com/flimzy/kivik/node_modules
adding /home/travis/gopath/pkg to cache
creating directory /home/travis/gopath/pkg
adding /var/lib/docker to cache
docker is not yet cached
/var/lib/docker: Permission denied
```