### PR TITLE
Add better support for Attachments

### DIFF
--- a/attachments_test.go
+++ b/attachments_test.go
@@ -117,3 +117,102 @@ func TestAttachmentMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestAttachmentUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+
+		body     string
+		expected *Attachment
+		err      string
+	}{
+		{
+			name: "stub",
+			input: `{
+					"content_type": "text/plain",
+					"stub": true
+				}`,
+			expected: &Attachment{
+				ContentType: "text/plain",
+				Stub:        true,
+			},
+		},
+		{
+			name: "simple",
+			input: `{
+					"content_type": "text/plain",
+					"data": "dGVzdCBhdHRhY2htZW50Cg=="
+				}`,
+			body: "test attachment\n",
+			expected: &Attachment{
+				ContentType: "text/plain",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := new(Attachment)
+			err := json.Unmarshal([]byte(test.input), result)
+			testy.Error(t, test.err, err)
+			var body []byte
+			if result.ReadCloser != nil {
+				body, err = ioutil.ReadAll(result)
+				if err != nil {
+					t.Fatal(err)
+				}
+				result.ReadCloser = nil
+			}
+			if d := diff.Text(test.body, string(body)); d != nil {
+				t.Errorf("Unexpected body:\n%s", d)
+			}
+			if d := diff.Interface(test.expected, result); d != nil {
+				t.Errorf("Unexpected result:\n%s", d)
+			}
+		})
+	}
+}
+
+func TestAttachmentsUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+
+		expected Attachments
+		err      string
+	}{
+		{
+			name:     "no attachments",
+			input:    "{}",
+			expected: Attachments{},
+		},
+		{
+			name: "one attachment",
+			input: `{
+				"foo.txt": {
+					"content_type": "text/plain",
+					"data": "dGVzdCBhdHRhY2htZW50Cg=="
+				}
+			}`,
+			expected: Attachments{
+				"foo.txt": &Attachment{
+					Filename:    "foo.txt",
+					ContentType: "text/plain",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var att Attachments
+			err := json.Unmarshal([]byte(test.input), &att)
+			testy.Error(t, test.err, err)
+			for _, v := range att {
+				v.ReadCloser = nil
+			}
+			if d := diff.Interface(test.expected, att); d != nil {
+				t.Error(d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With this, it should be possible to embed `kivik.Attachment` and `kivik.Attachments` fields in documents for use by `Put` and `Get`. Example:

```
doc := map[string]interface{}{
    // .. other fields
    "_attachments": kivik.Attachments{
        "foo.txt": &kivik.Attachment{
            ReadCloser: ioutil.NopCloser(strings.NewReader("test content"),
            ContentType: "text/plain",
        },
    },
}
```

Fixes #95.